### PR TITLE
Add leader share-to-clan feature

### DIFF
--- a/elixir.py
+++ b/elixir.py
@@ -220,8 +220,30 @@ async def on_message(message):
                 if result is None:
                     await message.reply("Something went wrong on my end — try again? 🧪")
                     return
-                # NOTE: leader-lounge responses are NOT written to elixir.json (private)
+
                 content = result.get("content", result.get("summary", ""))
+
+                # If the leader asked to share something with the clan, post to #elixir
+                if result.get("event_type") == "leader_share":
+                    share_content = result.get("share_content", "")
+                    if share_content:
+                        elixir_channel = bot.get_channel(ANNOUNCEMENTS_CHANNEL_ID)
+                        if elixir_channel:
+                            share_entry = {
+                                "event_type": "leader_share",
+                                "member_tags": result.get("member_tags", []),
+                                "member_names": result.get("member_names", []),
+                                "summary": result.get("summary", ""),
+                                "content": share_content,
+                                "metadata": {
+                                    "shared_by": message.author.display_name,
+                                },
+                            }
+                            saved = await _write_and_push(
+                                share_entry,
+                                f"Elixir: leader share from {message.author.display_name}",
+                            )
+                            await _post_to_elixir(elixir_channel, saved)
 
                 # Save Elixir's response to conversation memory
                 db.save_conversation_turn(

--- a/elixir_agent.py
+++ b/elixir_agent.py
@@ -62,9 +62,21 @@ LEADER_SYSTEM = (
     "You may be provided with recent conversation history with this leader. "
     "Use it for context — reference earlier questions and answers naturally. "
     "Don't repeat yourself if you already covered a topic recently.\n\n"
+    "## Sharing to the clan\n"
+    "A leader may ask you to share a point, insight, or announcement with the whole clan "
+    "(e.g. \"share that with the clan\", \"post that to #elixir\", \"announce that\"). "
+    "When they do, use event_type \"leader_share\" and include a \"share_content\" field "
+    "with a message crafted for the whole clan in #elixir. The \"content\" field should be "
+    "your reply to the leader confirming what you shared. "
+    "The share_content should be written for a general clan audience — motivational, clear, "
+    "and without referencing the private leader-lounge discussion.\n\n"
     "Respond with JSON only (no markdown wrapper):\n"
     '{"event_type": "leader_response", "member_tags": [], "member_names": [], '
-    '"summary": "one sentence TL;DR", "content": "full Discord-ready markdown response", "metadata": {}}'
+    '"summary": "one sentence TL;DR", "content": "full Discord-ready markdown response", "metadata": {}}\n\n'
+    "Or, when sharing to the clan:\n"
+    '{"event_type": "leader_share", "member_tags": [], "member_names": [], '
+    '"summary": "one sentence TL;DR", "content": "reply to the leader confirming the share", '
+    '"share_content": "the clan-facing post for #elixir", "metadata": {}}'
 )
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -224,6 +224,41 @@ def test_respond_to_leader_without_history(_mock_openai_client):
     assert result["event_type"] == "leader_response"
 
 
+def test_leader_share_event_type_in_prompt():
+    """LEADER_SYSTEM prompt describes the leader_share event type."""
+    assert "leader_share" in elixir_agent.LEADER_SYSTEM
+    assert "share_content" in elixir_agent.LEADER_SYSTEM
+
+
+def test_respond_to_leader_share(_mock_openai_client):
+    """Leader asking to share produces a leader_share response with share_content."""
+    final = json.dumps({
+        "event_type": "leader_share",
+        "member_tags": [],
+        "member_names": ["King Levy"],
+        "summary": "Shout out to King Levy",
+        "content": "Done! I posted a shout-out to King Levy in #elixir. 🧪",
+        "share_content": "👑 Big shout-out to **King Levy** for crushing it this week! Keep it up, kings! 🧪",
+        "metadata": {},
+    })
+    mock_resp = _make_mock_response(content=final)
+    _mock_openai_client.chat.completions.create.return_value = mock_resp
+
+    result = elixir_agent.respond_to_leader(
+        question="Share a shout-out to King Levy with the clan",
+        author_name="LeaderBob",
+        clan_data={"memberList": []},
+        war_data={},
+        recent_entries=[],
+    )
+
+    assert result["event_type"] == "leader_share"
+    assert "share_content" in result
+    assert "King Levy" in result["share_content"]
+    # The content field is the reply to the leader
+    assert "#elixir" in result["content"]
+
+
 def test_execute_tool_war_champ_standings():
     """War Champ standings tool returns serialized results."""
     with patch("elixir_agent.db") as mock_db:


### PR DESCRIPTION
Leaders in #leader-lounge can now ask Elixir to share insights with the whole clan. When the LLM detects a share request, it responds with event_type "leader_share" and a separate share_content field crafted for the clan audience. The bot posts share_content to #elixir, journals it, and confirms back to the leader.

https://claude.ai/code/session_014CketDar6yN7ER5qj3Wqd7