### PR TITLE
Add #reception onboarding: welcome, name matching, and role assignment

### DIFF
--- a/elixir.py
+++ b/elixir.py
@@ -27,6 +27,8 @@ CHICAGO = pytz.timezone("America/Chicago")
 TOKEN = os.getenv("DISCORD_TOKEN")
 ANNOUNCEMENTS_CHANNEL_ID = int(os.getenv("DISCORD_ANNOUNCEMENTS_CHANNEL", "0"))
 LEADERSHIP_CHANNEL_ID = int(os.getenv("DISCORD_LEADERSHIP_CHANNEL", "0"))
+RECEPTION_CHANNEL_ID = int(os.getenv("DISCORD_RECEPTION_CHANNEL", "0"))
+MEMBER_ROLE_ID = int(os.getenv("DISCORD_MEMBER_ROLE", "0"))
 POAPKINGS_REPO = os.path.expanduser(os.getenv("POAPKINGS_REPO_PATH", "../poapkings.com"))
 
 # Active hours for the heartbeat (Chicago time). Outside this window, heartbeat is skipped.
@@ -35,6 +37,7 @@ HEARTBEAT_END_HOUR = int(os.getenv("HEARTBEAT_END_HOUR", "22"))
 
 intents = discord.Intents.default()
 intents.message_content = True
+intents.members = True
 bot = commands.Bot(command_prefix="!", intents=intents)
 scheduler = AsyncIOScheduler(timezone=CHICAGO)
 
@@ -58,6 +61,19 @@ async def _write_and_push(entry: dict, commit_msg: str):
     saved = journal.append_entry(POAPKINGS_REPO, entry)
     journal.commit_and_push(POAPKINGS_REPO, commit_msg)
     return saved
+
+
+def _match_clan_member(nickname):
+    """Match a Discord nickname to a clan member. Returns (tag, name) or None.
+
+    Uses member_snapshot.json for the current roster. Case-insensitive.
+    """
+    snapshot = heartbeat._load_snapshot()
+    normalized = nickname.lower().strip()
+    for tag, name in snapshot.items():
+        if name.lower().strip() == normalized:
+            return (tag, name)
+    return None
 
 
 # ── Heartbeat ────────────────────────────────────────────────────────────────
@@ -175,6 +191,73 @@ async def on_ready():
 
 
 @bot.event
+async def on_member_join(member):
+    """Welcome new Discord members in #reception."""
+    channel = bot.get_channel(RECEPTION_CHANNEL_ID)
+    if not channel:
+        return
+    await channel.send(
+        f"👋 Welcome to the **POAP KINGS** Discord, {member.mention}!\n\n"
+        f"To get full access, please update your **server nickname** to match "
+        f"your **Clash Royale in-game name** exactly.\n\n"
+        f"**How to change your nickname:**\n"
+        f"• **Desktop** — Right-click your name in the member list → "
+        f"*Edit Server Profile* → change nickname\n"
+        f"• **Mobile** — Tap the server name at the top → "
+        f"*Edit Server Profile* → change nickname\n\n"
+        f"Once I see a match with our clan roster, I'll unlock the rest of the "
+        f"server for you. Need help? Just tag me! 🧪"
+    )
+
+
+@bot.event
+async def on_member_update(before, after):
+    """Detect nickname changes and grant member role when name matches a clan member."""
+    if before.nick == after.nick:
+        return
+    if not after.nick:
+        return
+
+    # Only act if they don't already have the member role
+    if not MEMBER_ROLE_ID:
+        return
+    member_role = after.guild.get_role(MEMBER_ROLE_ID)
+    if not member_role or member_role in after.roles:
+        return
+
+    match = _match_clan_member(after.nick)
+    channel = bot.get_channel(RECEPTION_CHANNEL_ID)
+
+    if not match:
+        if channel:
+            await channel.send(
+                f"Hmm {after.mention}, I don't see **{after.nick}** in our clan roster. "
+                f"Make sure your server nickname matches your Clash Royale name exactly. "
+                f"Tag me if you need help! 🧪"
+            )
+        return
+
+    tag, cr_name = match
+    try:
+        await after.add_roles(member_role, reason=f"Matched clan member: {cr_name} ({tag})")
+    except discord.Forbidden:
+        log.error("Cannot assign member role — check bot permissions and role hierarchy")
+        if channel:
+            await channel.send(
+                f"I matched **{cr_name}** but couldn't assign the role — "
+                f"a leader will need to help. 🧪"
+            )
+        return
+
+    if channel:
+        await channel.send(
+            f"✅ **Welcome aboard, {cr_name}!** {after.mention}\n\n"
+            f"Matched you to your Clash Royale account (`{tag}`). "
+            f"You now have full access — head to the other channels and say hi! 🧪"
+        )
+
+
+@bot.event
 async def on_message(message):
     if message.author.bot:
         return
@@ -183,6 +266,33 @@ async def on_message(message):
 
     # #elixir channel — broadcast only, Elixir does not respond here
     if message.channel.id == ANNOUNCEMENTS_CHANNEL_ID:
+        return
+
+    # #reception — onboarding help
+    if message.channel.id == RECEPTION_CHANNEL_ID:
+        async with message.channel.typing():
+            try:
+                clan = cr_api.get_clan()
+                question = message.content.replace(f"<@{bot.user.id}>", "").strip()
+                result = elixir_agent.respond_in_reception(
+                    question=question,
+                    author_name=message.author.display_name,
+                    clan_data=clan,
+                )
+                if result is None:
+                    await message.reply(
+                        "Having a hiccup — try again in a sec! 🧪"
+                    )
+                    return
+                content = result.get("content", result.get("summary", ""))
+                if len(content) > 2000:
+                    for chunk in [content[i:i+1990] for i in range(0, len(content), 1990)]:
+                        await message.reply(chunk)
+                else:
+                    await message.reply(content)
+            except Exception as e:
+                log.error("reception error: %s", e)
+                await message.reply("Hit an error — try again in a moment. 🧪")
         return
 
     # #leader-lounge — relay everything to the agent

--- a/elixir_agent.py
+++ b/elixir_agent.py
@@ -79,6 +79,23 @@ LEADER_SYSTEM = (
     '"share_content": "the clan-facing post for #elixir", "metadata": {}}'
 )
 
+RECEPTION_SYSTEM = (
+    ELIXIR_PERSONALITY + "\n\n"
+    "You are greeting a new member in the #reception channel of the POAP KINGS Discord server. "
+    "They need to change their Discord **server nickname** to match their **Clash Royale in-game name** "
+    "exactly so you can verify them and grant access to the rest of the server.\n\n"
+    "**How to change nickname:**\n"
+    "• Desktop — Right-click your name in the member list → Edit Server Profile → change nickname\n"
+    "• Mobile — Tap the server name at the top → Edit Server Profile → change nickname\n\n"
+    "The current clan roster is provided below. If they tell you their in-game name, confirm "
+    "whether it's in the roster and remind them to set it as their nickname. "
+    "If their name isn't in the roster, they may not be in the clan yet — tell them to join "
+    "clan tag #J2RGCRVG in Clash Royale first.\n\n"
+    "Be friendly, brief, and helpful. Don't use tools — just answer from the roster provided.\n\n"
+    "Respond with JSON only (no markdown wrapper):\n"
+    '{"event_type": "reception_response", "content": "your Discord-ready response"}'
+)
+
 
 # ── Tool definitions for OpenAI function calling ────────────────────────────
 
@@ -382,3 +399,18 @@ def respond_to_leader(question, author_name, clan_data, war_data, recent_entries
     user_msg = f"Leader '{author_name}' asks: {question}\n\n{context}"
     return _chat_with_tools(LEADER_SYSTEM, user_msg,
                             conversation_history=conversation_history)
+
+
+def respond_in_reception(question, author_name, clan_data):
+    """Onboarding Q&A in #reception. No tools needed. Returns dict or None."""
+    members = clan_data.get("memberList", clan_data.get("members", []))
+    roster = "\n".join(
+        f"  {m.get('name', '?')} ({m.get('tag', '?')})"
+        for m in members
+    ) or "  (roster unavailable)"
+    user_msg = (
+        f"New member '{author_name}' asks: {question}\n\n"
+        f"=== CLAN ROSTER ===\n{roster}"
+    )
+    return _chat_with_tools(RECEPTION_SYSTEM, user_msg,
+                            temperature=0.7, max_tokens=400)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -259,6 +259,39 @@ def test_respond_to_leader_share(_mock_openai_client):
     assert "#elixir" in result["content"]
 
 
+def test_reception_system_prompt():
+    """RECEPTION_SYSTEM prompt describes onboarding instructions."""
+    assert "server nickname" in elixir_agent.RECEPTION_SYSTEM.lower()
+    assert "Clash Royale" in elixir_agent.RECEPTION_SYSTEM
+    assert "reception_response" in elixir_agent.RECEPTION_SYSTEM
+
+
+def test_respond_in_reception(_mock_openai_client):
+    """Reception Q&A returns a helpful onboarding response."""
+    final = json.dumps({
+        "event_type": "reception_response",
+        "content": "Hey! I can see **King Levy** in our roster. Set that as your server nickname and I'll get you in! 🧪",
+    })
+    mock_resp = _make_mock_response(content=final)
+    _mock_openai_client.chat.completions.create.return_value = mock_resp
+
+    result = elixir_agent.respond_in_reception(
+        question="My name is King Levy",
+        author_name="NewUser",
+        clan_data={"memberList": [{"name": "King Levy", "tag": "#ABC"}]},
+    )
+
+    assert result["event_type"] == "reception_response"
+    assert "King Levy" in result["content"]
+
+    # Verify roster appeared in user message
+    call_args = _mock_openai_client.chat.completions.create.call_args
+    messages = call_args.kwargs.get("messages") or call_args[1].get("messages")
+    user_msg = messages[1]["content"]
+    assert "King Levy" in user_msg
+    assert "#ABC" in user_msg
+
+
 def test_execute_tool_war_champ_standings():
     """War Champ standings tool returns serialized results."""
     with patch("elixir_agent.db") as mock_db:

--- a/tests/test_reception.py
+++ b/tests/test_reception.py
@@ -1,0 +1,53 @@
+"""Tests for #reception onboarding — name matching and event handlers."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+# We test _match_clan_member by patching the snapshot it reads
+import elixir
+
+
+SAMPLE_SNAPSHOT = {
+    "#ABC123": "King Levy",
+    "#DEF456": "Vijay",
+    "#GHI789": "JaxikoLane",
+}
+
+
+class TestMatchClanMember:
+    """Tests for the _match_clan_member helper."""
+
+    def _match(self, nickname):
+        with patch("elixir.heartbeat._load_snapshot", return_value=SAMPLE_SNAPSHOT):
+            return elixir._match_clan_member(nickname)
+
+    def test_exact_match(self):
+        result = self._match("King Levy")
+        assert result == ("#ABC123", "King Levy")
+
+    def test_case_insensitive(self):
+        result = self._match("king levy")
+        assert result == ("#ABC123", "King Levy")
+
+    def test_case_insensitive_upper(self):
+        result = self._match("VIJAY")
+        assert result == ("#DEF456", "Vijay")
+
+    def test_whitespace_stripped(self):
+        result = self._match("  King Levy  ")
+        assert result == ("#ABC123", "King Levy")
+
+    def test_no_match(self):
+        result = self._match("UnknownPlayer")
+        assert result is None
+
+    def test_empty_nickname(self):
+        result = self._match("")
+        assert result is None
+
+    def test_empty_snapshot(self):
+        with patch("elixir.heartbeat._load_snapshot", return_value={}):
+            result = elixir._match_clan_member("King Levy")
+        assert result is None


### PR DESCRIPTION
New members land in #reception where Elixir welcomes them and asks them to set their Discord server nickname to match their Clash Royale name. on_member_update detects nickname changes and matches against the clan roster (case-insensitive). On match, the member role is assigned automatically granting access to the rest of the server.

Also adds LLM-powered Q&A in #reception so Elixir can help new members with the process, and a RECEPTION_SYSTEM prompt in elixir_agent.py.

Requires new env vars: DISCORD_RECEPTION_CHANNEL, DISCORD_MEMBER_ROLE Requires enabling the Members privileged intent in the Discord dev portal.

https://claude.ai/code/session_014CketDar6yN7ER5qj3Wqd7