### PR TITLE
Add contextual memory subsystem with DB migration, search, and summarization

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -1,0 +1,101 @@
+# Elixir Memory System — Implementation Notes
+
+## What was added
+
+Implemented an end-to-end contextual memory subsystem with explicit storage and retrieval separation from authoritative clan/game records.
+
+### New modules
+
+- `memory_store/`
+  - CRUD and lifecycle operations (`create`, `update`, `archive`, `soft delete`)
+  - Provenance validation (`source_type`, `is_inference`, `confidence` rules)
+  - Scope-aware permissions (`public`, `leadership`, `system_internal`)
+  - Structured filters + hybrid retrieval (FTS + embedding similarity)
+  - Reciprocal Rank Fusion merge and deterministic tie-breaks
+  - Tag/evidence linkage helpers
+
+- `memory_reasoner/`
+  - Summarization helpers that keep source classes separate
+  - Prompt packaging into distinct provenance sections
+  - Response phrasing helpers that hedge inferences
+
+### Database migration
+
+Added `_migration_8` in `db/__init__.py` with:
+
+- `clan_memories` core table
+- Related tables:
+  - `clan_memory_tags`
+  - `clan_memory_tag_links`
+  - `clan_memory_member_links`
+  - `clan_memory_event_links`
+  - `clan_memory_evidence_refs`
+  - `clan_memory_versions`
+  - `clan_memory_audit_log`
+  - `clan_memory_embeddings`
+  - `clan_memory_index_status`
+- FTS5 virtual table + sync triggers (`clan_memories_fts`)
+- Access-path indexes for scope/status/member/war/event/source lookups
+- Best-effort sqlite-vec initialization (`clan_memory_vec`) with degraded-mode flag persistence in `clan_memory_index_status`
+
+## Architectural decisions
+
+1. **Strict separation from authoritative facts**
+   - Existing `memory_facts` / `memory_episodes` and all V2 authoritative clan/game paths remain unchanged.
+   - New contextual memory lives only in `clan_memory*` tables and `memory_store`/`memory_reasoner` code paths.
+
+2. **Provenance enforcement in two layers**
+   - DB `CHECK` constraints for immutable baseline guarantees.
+   - Service-layer validation errors for clear developer feedback.
+
+3. **Hybrid retrieval with graceful degradation**
+   - Primary lexical retrieval uses FTS5 (`MATCH` + `bm25`).
+   - Semantic retrieval uses stored embeddings (`text-embedding-3-small` expected) and cosine similarity.
+   - RRF merges both rank lists.
+   - If FTS fails, retrieval degrades to substring lexical ranking.
+   - If embeddings are absent/unavailable, lexical-only search still works.
+
+4. **Auditability and safe mutation**
+   - Updates snapshot previous state into `clan_memory_versions`.
+   - All writes add `clan_memory_audit_log` entries.
+   - Archive/delete are soft-status transitions, not destructive deletes.
+
+## Assumptions
+
+- Existing authoritative data queries remain the source of truth for member/war/fact questions.
+- `sqlite-vec` may not be present in all local/dev runtimes.
+- Embeddings are generated externally and supplied via `upsert_embedding`; this repo does not run embedding API calls directly inside the store layer.
+
+## How migrations run
+
+Migrations run automatically through `db.get_connection()`.
+
+No manual migration command is required.
+
+## Embedding configuration
+
+- Preferred embedding model: `text-embedding-3-small`.
+- Query embedding can be injected into `search_memories(..., embed_query=callable)`.
+- Memory embedding rows are stored in `clan_memory_embeddings` via `upsert_embedding`.
+
+## Running tests
+
+```bash
+venv/bin/python -m pytest tests/test_memory_system.py -v
+venv/bin/python -m pytest tests/test_db_v2.py -v
+```
+
+## Degraded mode behavior
+
+- If `sqlite-vec` cannot initialize, the system marks `sqlite_vec_enabled = 0` and continues.
+- If query embedding is unavailable, lexical-only search is used.
+- If FTS query errors, lexical substring fallback runs against filtered candidates.
+- Expired, archived, and deleted memories are excluded by default unless explicitly included.
+
+## Manual review items before production rollout
+
+1. Confirm `sqlite-vec` extension availability in production runtime.
+2. Decide final write-policy boundaries for who can create `leader_note` vs `system` records.
+3. Add runtime wiring from command/workflow handlers into `memory_store` write/read methods.
+4. Add prompt-integration wiring to consume `memory_reasoner.package_prompt_context` where appropriate.
+5. Validate retention policy defaults (`retention_class`, optional expiration for low-confidence inferences).

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1021,7 +1021,185 @@ def _migration_7(conn: sqlite3.Connection) -> None:
             conn.execute(f"ALTER TABLE member_battle_facts ADD COLUMN {name} {sql_type}")
 
 
-_MIGRATIONS = [_migration_0, _migration_1, _migration_2, _migration_3, _migration_4, _migration_5, _migration_6, _migration_7]
+def _migration_8(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS clan_memories (
+            memory_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            created_by TEXT NOT NULL,
+            updated_by TEXT NOT NULL,
+            source_type TEXT NOT NULL,
+            is_inference INTEGER NOT NULL,
+            confidence REAL NOT NULL,
+            scope TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'active',
+            title TEXT,
+            body TEXT NOT NULL,
+            summary TEXT,
+            member_id INTEGER,
+            member_tag TEXT,
+            role TEXT,
+            channel_id TEXT,
+            war_season_id TEXT,
+            war_week_id TEXT,
+            event_type TEXT,
+            event_id TEXT,
+            retention_class TEXT NOT NULL DEFAULT 'standard',
+            expires_at TEXT,
+            metadata_json TEXT,
+            embedding_model TEXT,
+            embedding_created_at TEXT,
+            FOREIGN KEY(member_id) REFERENCES members(member_id) ON DELETE SET NULL,
+            CHECK(source_type IN ('leader_note', 'elixir_inference', 'system')),
+            CHECK(scope IN ('public', 'leadership', 'system_internal')),
+            CHECK(status IN ('active', 'archived', 'deleted')),
+            CHECK(is_inference IN (0, 1)),
+            CHECK(confidence >= 0.0 AND confidence <= 1.0),
+            CHECK(source_type != 'elixir_inference' OR (is_inference = 1 AND confidence < 1.0))
+        );
+
+        CREATE TABLE IF NOT EXISTS clan_memory_tags (
+            tag_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tag TEXT NOT NULL UNIQUE,
+            created_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS clan_memory_tag_links (
+            memory_id INTEGER NOT NULL REFERENCES clan_memories(memory_id) ON DELETE CASCADE,
+            tag_id INTEGER NOT NULL REFERENCES clan_memory_tags(tag_id) ON DELETE CASCADE,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY(memory_id, tag_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS clan_memory_member_links (
+            memory_member_link_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            memory_id INTEGER NOT NULL REFERENCES clan_memories(memory_id) ON DELETE CASCADE,
+            member_id INTEGER REFERENCES members(member_id) ON DELETE SET NULL,
+            member_tag TEXT,
+            relation_type TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS clan_memory_event_links (
+            memory_event_link_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            memory_id INTEGER NOT NULL REFERENCES clan_memories(memory_id) ON DELETE CASCADE,
+            event_type TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE(memory_id, event_type, event_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS clan_memory_evidence_refs (
+            evidence_ref_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            memory_id INTEGER NOT NULL REFERENCES clan_memories(memory_id) ON DELETE CASCADE,
+            evidence_type TEXT NOT NULL,
+            evidence_ref TEXT NOT NULL,
+            evidence_label TEXT,
+            evidence_url TEXT,
+            metadata_json TEXT,
+            created_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS clan_memory_versions (
+            memory_version_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            memory_id INTEGER NOT NULL REFERENCES clan_memories(memory_id) ON DELETE CASCADE,
+            version_number INTEGER NOT NULL,
+            changed_at TEXT NOT NULL,
+            changed_by TEXT NOT NULL,
+            title TEXT,
+            body TEXT,
+            summary TEXT,
+            status TEXT,
+            scope TEXT,
+            metadata_json TEXT,
+            confidence REAL,
+            UNIQUE(memory_id, version_number)
+        );
+
+        CREATE TABLE IF NOT EXISTS clan_memory_audit_log (
+            audit_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            memory_id INTEGER NOT NULL REFERENCES clan_memories(memory_id) ON DELETE CASCADE,
+            changed_at TEXT NOT NULL,
+            changed_by TEXT NOT NULL,
+            action TEXT NOT NULL,
+            payload_json TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS clan_memory_embeddings (
+            memory_id INTEGER PRIMARY KEY REFERENCES clan_memories(memory_id) ON DELETE CASCADE,
+            embedding_model TEXT NOT NULL,
+            vector_json TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS clan_memory_index_status (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+
+        INSERT OR IGNORE INTO clan_memory_index_status (key, value) VALUES ('sqlite_vec_enabled', '0');
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS clan_memories_fts USING fts5(
+            title,
+            summary,
+            body,
+            content='clan_memories',
+            content_rowid='memory_id'
+        );
+
+        CREATE TRIGGER IF NOT EXISTS clan_memories_ai AFTER INSERT ON clan_memories BEGIN
+            INSERT INTO clan_memories_fts(rowid, title, summary, body)
+            VALUES (new.memory_id, new.title, new.summary, new.body);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS clan_memories_ad AFTER DELETE ON clan_memories BEGIN
+            INSERT INTO clan_memories_fts(clan_memories_fts, rowid, title, summary, body)
+            VALUES('delete', old.memory_id, old.title, old.summary, old.body);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS clan_memories_au AFTER UPDATE ON clan_memories BEGIN
+            INSERT INTO clan_memories_fts(clan_memories_fts, rowid, title, summary, body)
+            VALUES('delete', old.memory_id, old.title, old.summary, old.body);
+            INSERT INTO clan_memories_fts(rowid, title, summary, body)
+            VALUES (new.memory_id, new.title, new.summary, new.body);
+        END;
+
+        CREATE INDEX IF NOT EXISTS idx_clan_memories_scope_status_created
+            ON clan_memories(scope, status, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_clan_memories_member
+            ON clan_memories(member_id, member_tag, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_clan_memories_war
+            ON clan_memories(war_season_id, war_week_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_clan_memories_event
+            ON clan_memories(event_type, event_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_clan_memories_source
+            ON clan_memories(source_type, is_inference, confidence, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_clan_memory_evidence_lookup
+            ON clan_memory_evidence_refs(memory_id, evidence_type, evidence_ref);
+        CREATE INDEX IF NOT EXISTS idx_clan_memory_member_links_lookup
+            ON clan_memory_member_links(member_id, member_tag, relation_type);
+        CREATE INDEX IF NOT EXISTS idx_clan_memory_event_links_lookup
+            ON clan_memory_event_links(event_type, event_id);
+        """
+    )
+
+    try:
+        conn.execute(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS clan_memory_vec USING vec0(memory_id INTEGER PRIMARY KEY, embedding float[1536])"
+        )
+        conn.execute(
+            "UPDATE clan_memory_index_status SET value = '1' WHERE key = 'sqlite_vec_enabled'"
+        )
+    except sqlite3.OperationalError:
+        conn.execute(
+            "UPDATE clan_memory_index_status SET value = '0' WHERE key = 'sqlite_vec_enabled'"
+        )
+
+
+_MIGRATIONS = [_migration_0, _migration_1, _migration_2, _migration_3, _migration_4, _migration_5, _migration_6, _migration_7, _migration_8]
 
 
 def _run_migrations(conn: sqlite3.Connection) -> None:

--- a/memory_reasoner/__init__.py
+++ b/memory_reasoner/__init__.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from memory_store import list_memories, search_memories
+
+
+@dataclass
+class MemorySummary:
+    facts: list[dict]
+    leadership_notes: list[dict]
+    assistant_inferences: list[dict]
+    system_notes: list[dict]
+    open_questions: list[str]
+
+
+def package_prompt_context(*, facts: Optional[list[dict]] = None, memories: Optional[list[dict]] = None) -> dict:
+    facts = facts or []
+    memories = memories or []
+    leadership = [m for m in memories if m.get("source_type") == "leader_note"]
+    inferences = [m for m in memories if m.get("source_type") == "elixir_inference"]
+    system_notes = [m for m in memories if m.get("source_type") == "system"]
+    return {
+        "facts": facts,
+        "leadership_memories": leadership,
+        "assistant_inferences": inferences,
+        "system_notes": system_notes,
+    }
+
+
+def summarize_memories(*, facts: Optional[list[dict]] = None, memories: Optional[list[dict]] = None) -> MemorySummary:
+    packet = package_prompt_context(facts=facts, memories=memories)
+    open_questions = []
+    for inference in packet["assistant_inferences"]:
+        conf = float(inference.get("confidence") or 0.0)
+        if conf < 0.6:
+            open_questions.append(
+                f"Inference {inference.get('memory_id')} has low confidence ({conf:.2f}) and needs confirmation."
+            )
+    return MemorySummary(
+        facts=packet["facts"],
+        leadership_notes=packet["leadership_memories"],
+        assistant_inferences=packet["assistant_inferences"],
+        system_notes=packet["system_notes"],
+        open_questions=open_questions,
+    )
+
+
+def summarize_member_memories(member_id: int, *, viewer_scope: str = "leadership", conn=None) -> MemorySummary:
+    memories = list_memories(viewer_scope=viewer_scope, filters={"member_id": member_id}, conn=conn)
+    return summarize_memories(memories=memories)
+
+
+def summarize_war_week_memories(war_week_id: str, *, viewer_scope: str = "leadership", conn=None) -> MemorySummary:
+    memories = list_memories(viewer_scope=viewer_scope, filters={"war_week_id": war_week_id}, conn=conn)
+    return summarize_memories(memories=memories)
+
+
+def summarize_war_season_memories(war_season_id: str, *, viewer_scope: str = "leadership", conn=None) -> MemorySummary:
+    memories = list_memories(viewer_scope=viewer_scope, filters={"war_season_id": war_season_id}, conn=conn)
+    return summarize_memories(memories=memories)
+
+
+def summarize_topic_date_range(topic: str, *, created_after: Optional[str] = None, created_before: Optional[str] = None,
+                               viewer_scope: str = "leadership", conn=None) -> MemorySummary:
+    results = search_memories(
+        topic,
+        viewer_scope=viewer_scope,
+        filters={"created_after": created_after, "created_before": created_before},
+        conn=conn,
+    )
+    return summarize_memories(memories=[r.memory for r in results])
+
+
+def format_memory_for_response(memory: dict) -> str:
+    source = memory.get("source_type")
+    if source == "leader_note":
+        return f"Leadership noted: {memory.get('summary') or memory.get('body')}"
+    if source == "elixir_inference":
+        conf = float(memory.get("confidence") or 0.0)
+        label = "low" if conf < 0.5 else "moderate" if conf < 0.8 else "high"
+        return f"Elixir inferred with {label} confidence ({conf:.2f}) that {memory.get('summary') or memory.get('body')}"
+    return f"System record indicates: {memory.get('summary') or memory.get('body')}"
+
+
+__all__ = [
+    "MemorySummary",
+    "package_prompt_context",
+    "summarize_memories",
+    "summarize_member_memories",
+    "summarize_war_week_memories",
+    "summarize_war_season_memories",
+    "summarize_topic_date_range",
+    "format_memory_for_response",
+]

--- a/memory_store/__init__.py
+++ b/memory_store/__init__.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Iterable, Optional
+
+from db import _canon_tag, _json_or_none, _rowdicts, _utcnow, get_connection
+
+SOURCE_TYPES = {"leader_note", "elixir_inference", "system"}
+SCOPES = {"public", "leadership", "system_internal"}
+STATUSES = {"active", "archived", "deleted"}
+
+
+class MemoryValidationError(ValueError):
+    pass
+
+
+@dataclass
+class MemorySearchResult:
+    memory: dict
+    rank_score: float
+    components: dict
+
+
+def _validate_provenance(source_type: str, is_inference: bool, confidence: float) -> None:
+    if source_type not in SOURCE_TYPES:
+        raise MemoryValidationError(f"invalid source_type: {source_type}")
+    if not (0.0 <= float(confidence) <= 1.0):
+        raise MemoryValidationError("confidence must be between 0.0 and 1.0")
+    if source_type == "leader_note" and is_inference:
+        raise MemoryValidationError("leader_note memories cannot be marked as inference")
+    if source_type == "elixir_inference" and not is_inference:
+        raise MemoryValidationError("elixir_inference memories must set is_inference=true")
+    if source_type == "elixir_inference" and float(confidence) >= 1.0:
+        raise MemoryValidationError("elixir_inference confidence must be less than 1.0")
+
+
+def _allowed_scopes(viewer_scope: str, include_system_internal: bool = False) -> tuple[str, ...]:
+    if viewer_scope == "public":
+        return ("public",)
+    if viewer_scope == "leadership":
+        scopes = ["public", "leadership"]
+        if include_system_internal:
+            scopes.append("system_internal")
+        return tuple(scopes)
+    if viewer_scope == "system_internal":
+        return ("public", "leadership", "system_internal")
+    raise MemoryValidationError(f"invalid viewer scope: {viewer_scope}")
+
+
+def _normalize_date(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if "T" in text:
+        datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return text
+    return datetime.strptime(text, "%Y-%m-%d").strftime("%Y-%m-%d")
+
+
+def _build_filter_where(filters: Optional[dict], args: list) -> str:
+    filters = filters or {}
+    clauses = []
+    if filters.get("member_id") is not None:
+        clauses.append("m.member_id = ?")
+        args.append(filters["member_id"])
+    if filters.get("member_tag"):
+        clauses.append("m.member_tag = ?")
+        args.append(_canon_tag(filters["member_tag"]))
+    for key in ("role", "war_season_id", "war_week_id", "event_type", "event_id", "scope", "source_type", "status"):
+        value = filters.get(key)
+        if value is not None:
+            clauses.append(f"m.{key} = ?")
+            args.append(value)
+    if filters.get("is_inference") is not None:
+        clauses.append("m.is_inference = ?")
+        args.append(1 if filters.get("is_inference") else 0)
+    created_after = _normalize_date(filters.get("created_after"))
+    created_before = _normalize_date(filters.get("created_before"))
+    if created_after:
+        clauses.append("m.created_at >= ?")
+        args.append(created_after)
+    if created_before:
+        clauses.append("m.created_at <= ?")
+        args.append(created_before)
+    return (" AND " + " AND ".join(clauses)) if clauses else ""
+
+
+def _fetch_memory(conn, memory_id: int) -> Optional[dict]:
+    row = conn.execute(
+        "SELECT * FROM clan_memories WHERE memory_id = ?",
+        (memory_id,),
+    ).fetchone()
+    if not row:
+        return None
+    item = dict(row)
+    item["metadata_json"] = json.loads(item["metadata_json"] or "{}")
+    item["tags"] = [
+        r["tag"] for r in conn.execute(
+            "SELECT t.tag FROM clan_memory_tags t JOIN clan_memory_tag_links l ON l.tag_id = t.tag_id WHERE l.memory_id = ? ORDER BY t.tag ASC",
+            (memory_id,),
+        ).fetchall()
+    ]
+    evidence = conn.execute(
+        "SELECT evidence_type, evidence_ref, evidence_label, evidence_url, metadata_json, created_at "
+        "FROM clan_memory_evidence_refs WHERE memory_id = ? ORDER BY evidence_ref_id ASC",
+        (memory_id,),
+    ).fetchall()
+    item["evidence_refs"] = [
+        {
+            **dict(r),
+            "metadata_json": json.loads(r["metadata_json"] or "{}"),
+        }
+        for r in evidence
+    ]
+    return item
+
+
+def create_memory(*, body: str, source_type: str, is_inference: bool, confidence: float,
+                  created_by: str, scope: str = "leadership", status: str = "active",
+                  title: Optional[str] = None, summary: Optional[str] = None,
+                  member_id: Optional[int] = None, member_tag: Optional[str] = None,
+                  role: Optional[str] = None, channel_id: Optional[str] = None,
+                  war_season_id: Optional[str] = None, war_week_id: Optional[str] = None,
+                  event_type: Optional[str] = None, event_id: Optional[str] = None,
+                  retention_class: str = "standard", expires_at: Optional[str] = None,
+                  metadata: Optional[dict] = None, conn=None) -> dict:
+    close = conn is None
+    conn = conn or get_connection()
+    try:
+        if scope not in SCOPES:
+            raise MemoryValidationError(f"invalid scope: {scope}")
+        if status not in STATUSES:
+            raise MemoryValidationError(f"invalid status: {status}")
+        _validate_provenance(source_type, is_inference, confidence)
+        now = _utcnow()
+        cur = conn.execute(
+            "INSERT INTO clan_memories (created_at, updated_at, created_by, updated_by, source_type, is_inference, confidence, "
+            "scope, status, title, body, summary, member_id, member_tag, role, channel_id, war_season_id, war_week_id, event_type, "
+            "event_id, retention_class, expires_at, metadata_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                now,
+                now,
+                created_by,
+                created_by,
+                source_type,
+                1 if is_inference else 0,
+                float(confidence),
+                scope,
+                status,
+                title,
+                body,
+                summary,
+                member_id,
+                _canon_tag(member_tag) if member_tag else None,
+                role,
+                str(channel_id) if channel_id else None,
+                war_season_id,
+                war_week_id,
+                event_type,
+                event_id,
+                retention_class,
+                _normalize_date(expires_at),
+                _json_or_none(metadata or {}),
+            ),
+        )
+        memory_id = cur.lastrowid
+        conn.execute(
+            "INSERT INTO clan_memory_audit_log (memory_id, changed_at, changed_by, action, payload_json) VALUES (?, ?, ?, 'create', ?)",
+            (memory_id, now, created_by, _json_or_none({"source_type": source_type, "scope": scope})),
+        )
+        conn.commit()
+        return _fetch_memory(conn, memory_id)
+    finally:
+        if close:
+            conn.close()
+
+
+def attach_tags(memory_id: int, tags: Iterable[str], *, actor: str, conn=None) -> list[str]:
+    close = conn is None
+    conn = conn or get_connection()
+    try:
+        clean = sorted({t.strip().lower() for t in (tags or []) if t and t.strip()})
+        for tag in clean:
+            conn.execute("INSERT OR IGNORE INTO clan_memory_tags (tag, created_at) VALUES (?, ?)", (tag, _utcnow()))
+            tag_row = conn.execute("SELECT tag_id FROM clan_memory_tags WHERE tag = ?", (tag,)).fetchone()
+            conn.execute(
+                "INSERT OR IGNORE INTO clan_memory_tag_links (memory_id, tag_id, created_at) VALUES (?, ?, ?)",
+                (memory_id, tag_row["tag_id"], _utcnow()),
+            )
+        conn.execute(
+            "INSERT INTO clan_memory_audit_log (memory_id, changed_at, changed_by, action, payload_json) VALUES (?, ?, ?, 'attach_tags', ?)",
+            (memory_id, _utcnow(), actor, _json_or_none({"tags": clean})),
+        )
+        conn.commit()
+        return clean
+    finally:
+        if close:
+            conn.close()
+
+
+def attach_evidence_ref(memory_id: int, *, evidence_type: str, evidence_ref: str,
+                        actor: str, evidence_label: Optional[str] = None,
+                        evidence_url: Optional[str] = None, metadata: Optional[dict] = None,
+                        conn=None) -> None:
+    close = conn is None
+    conn = conn or get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO clan_memory_evidence_refs (memory_id, evidence_type, evidence_ref, evidence_label, evidence_url, metadata_json, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (memory_id, evidence_type, evidence_ref, evidence_label, evidence_url, _json_or_none(metadata or {}), _utcnow()),
+        )
+        conn.execute(
+            "INSERT INTO clan_memory_audit_log (memory_id, changed_at, changed_by, action, payload_json) VALUES (?, ?, ?, 'attach_evidence', ?)",
+            (memory_id, _utcnow(), actor, _json_or_none({"evidence_type": evidence_type, "evidence_ref": evidence_ref})),
+        )
+        conn.commit()
+    finally:
+        if close:
+            conn.close()
+
+
+def update_memory(memory_id: int, *, actor: str, conn=None, **updates) -> dict:
+    close = conn is None
+    conn = conn or get_connection()
+    try:
+        current = _fetch_memory(conn, memory_id)
+        if not current:
+            raise MemoryValidationError(f"memory not found: {memory_id}")
+        merged = dict(current)
+        merged.update({k: v for k, v in updates.items() if v is not None})
+        _validate_provenance(merged["source_type"], bool(merged["is_inference"]), float(merged["confidence"]))
+
+        version = conn.execute(
+            "SELECT COALESCE(MAX(version_number), 0) AS version_no FROM clan_memory_versions WHERE memory_id = ?",
+            (memory_id,),
+        ).fetchone()["version_no"] + 1
+        conn.execute(
+            "INSERT INTO clan_memory_versions (memory_id, version_number, changed_at, changed_by, title, body, summary, status, scope, metadata_json, confidence) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                memory_id,
+                version,
+                _utcnow(),
+                actor,
+                current.get("title"),
+                current.get("body"),
+                current.get("summary"),
+                current.get("status"),
+                current.get("scope"),
+                _json_or_none(current.get("metadata_json") or {}),
+                current.get("confidence"),
+            ),
+        )
+        allowed = {
+            "title", "body", "summary", "status", "scope", "confidence", "source_type", "is_inference", "member_id", "member_tag",
+            "role", "channel_id", "war_season_id", "war_week_id", "event_type", "event_id", "retention_class", "expires_at", "metadata_json",
+        }
+        cols = []
+        args = []
+        for key, value in updates.items():
+            if key not in allowed:
+                continue
+            if key == "member_tag" and value:
+                value = _canon_tag(value)
+            if key == "is_inference":
+                value = 1 if value else 0
+            if key == "metadata":
+                key = "metadata_json"
+                value = _json_or_none(value)
+            if key == "expires_at":
+                value = _normalize_date(value)
+            cols.append(f"{key} = ?")
+            args.append(value)
+        cols.extend(["updated_at = ?", "updated_by = ?"])
+        args.extend([_utcnow(), actor, memory_id])
+        conn.execute(f"UPDATE clan_memories SET {', '.join(cols)} WHERE memory_id = ?", args)
+        conn.execute(
+            "INSERT INTO clan_memory_audit_log (memory_id, changed_at, changed_by, action, payload_json) VALUES (?, ?, ?, 'update', ?)",
+            (memory_id, _utcnow(), actor, _json_or_none({"fields": sorted([k for k in updates if k in allowed])})),
+        )
+        conn.commit()
+        return _fetch_memory(conn, memory_id)
+    finally:
+        if close:
+            conn.close()
+
+
+def archive_memory(memory_id: int, *, actor: str, conn=None) -> dict:
+    return update_memory(memory_id, actor=actor, status="archived", conn=conn)
+
+
+def soft_delete_memory(memory_id: int, *, actor: str, conn=None) -> dict:
+    return update_memory(memory_id, actor=actor, status="deleted", conn=conn)
+
+
+def get_memory(memory_id: int, *, viewer_scope: str = "leadership", include_system_internal: bool = False,
+               include_archived: bool = False, include_deleted: bool = False, conn=None) -> Optional[dict]:
+    close = conn is None
+    conn = conn or get_connection()
+    try:
+        scopes = _allowed_scopes(viewer_scope, include_system_internal=include_system_internal)
+        row = _fetch_memory(conn, memory_id)
+        if not row:
+            return None
+        if row["scope"] not in scopes:
+            return None
+        if row["status"] == "deleted" and not include_deleted:
+            return None
+        if row["status"] == "archived" and not include_archived:
+            return None
+        if row.get("expires_at") and row["expires_at"] <= _utcnow():
+            return None
+        return row
+    finally:
+        if close:
+            conn.close()
+
+
+def list_memories(*, viewer_scope: str = "leadership", include_system_internal: bool = False,
+                  include_archived: bool = False, include_deleted: bool = False,
+                  filters: Optional[dict] = None, limit: int = 50, conn=None) -> list[dict]:
+    close = conn is None
+    conn = conn or get_connection()
+    try:
+        scopes = _allowed_scopes(viewer_scope, include_system_internal=include_system_internal)
+        args: list = list(scopes)
+        sql = (
+            "SELECT m.memory_id FROM clan_memories m WHERE m.scope IN ({}) ".format(",".join("?" for _ in scopes))
+        )
+        if not include_archived:
+            sql += " AND m.status != 'archived'"
+        if not include_deleted:
+            sql += " AND m.status != 'deleted'"
+        sql += " AND (m.expires_at IS NULL OR m.expires_at > ?)"
+        args.append(_utcnow())
+        sql += _build_filter_where(filters, args)
+        sql += " ORDER BY m.created_at DESC, m.memory_id DESC LIMIT ?"
+        args.append(limit)
+        rows = conn.execute(sql, args).fetchall()
+        return [_fetch_memory(conn, row["memory_id"]) for row in rows]
+    finally:
+        if close:
+            conn.close()
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def upsert_embedding(memory_id: int, embedding: list[float], *, model: str = "text-embedding-3-small", conn=None) -> None:
+    close = conn is None
+    conn = conn or get_connection()
+    try:
+        now = _utcnow()
+        payload = json.dumps(embedding)
+        conn.execute(
+            "INSERT INTO clan_memory_embeddings (memory_id, embedding_model, vector_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(memory_id) DO UPDATE SET embedding_model = excluded.embedding_model, vector_json = excluded.vector_json, updated_at = excluded.updated_at",
+            (memory_id, model, payload, now, now),
+        )
+        conn.execute(
+            "UPDATE clan_memories SET embedding_model = ?, embedding_created_at = ? WHERE memory_id = ?",
+            (model, now, memory_id),
+        )
+        conn.commit()
+    finally:
+        if close:
+            conn.close()
+
+
+def _rrf_merge(lexical: list[int], vector: list[int], *, k: int = 60) -> dict[int, dict]:
+    scores: dict[int, dict] = {}
+    for rank, memory_id in enumerate(lexical, start=1):
+        item = scores.setdefault(memory_id, {"rrf": 0.0, "lexical_rank": None, "vector_rank": None})
+        item["rrf"] += 1.0 / (k + rank)
+        item["lexical_rank"] = rank
+    for rank, memory_id in enumerate(vector, start=1):
+        item = scores.setdefault(memory_id, {"rrf": 0.0, "lexical_rank": None, "vector_rank": None})
+        item["rrf"] += 1.0 / (k + rank)
+        item["vector_rank"] = rank
+    return scores
+
+
+def search_memories(query: str, *, viewer_scope: str = "leadership", include_system_internal: bool = False,
+                    filters: Optional[dict] = None, limit: int = 10,
+                    embed_query: Optional[Callable[[str], Optional[list[float]]]] = None,
+                    conn=None) -> list[MemorySearchResult]:
+    close = conn is None
+    conn = conn or get_connection()
+    try:
+        candidates = list_memories(
+            viewer_scope=viewer_scope,
+            include_system_internal=include_system_internal,
+            filters=filters,
+            limit=max(200, limit * 10),
+            conn=conn,
+        )
+        if not candidates:
+            return []
+        ids = [m["memory_id"] for m in candidates]
+
+        lexical_ranks: list[int] = []
+        q = (query or "").strip()
+        if q:
+            try:
+                placeholders = ",".join("?" for _ in ids)
+                fts_rows = conn.execute(
+                    "SELECT rowid AS memory_id, bm25(clan_memories_fts) AS score "
+                    "FROM clan_memories_fts WHERE clan_memories_fts MATCH ? AND rowid IN ({}) ORDER BY score ASC LIMIT ?".format(placeholders),
+                    (q, *ids, limit * 4),
+                ).fetchall()
+                lexical_ranks = [r["memory_id"] for r in fts_rows]
+            except Exception:
+                # FTS fallback (degraded mode)
+                ranked = []
+                low = q.lower()
+                for item in candidates:
+                    haystack = f"{item.get('title','')}\n{item.get('summary','')}\n{item.get('body','')}".lower()
+                    if low in haystack:
+                        ranked.append((haystack.count(low), item["memory_id"]))
+                ranked.sort(key=lambda x: (-x[0], x[1]))
+                lexical_ranks = [x[1] for x in ranked[: limit * 4]]
+        else:
+            lexical_ranks = ids[: limit * 4]
+
+        vector_ranks: list[int] = []
+        query_embedding = embed_query(q) if (q and embed_query) else None
+        if query_embedding:
+            emb_rows = conn.execute(
+                "SELECT memory_id, vector_json FROM clan_memory_embeddings WHERE memory_id IN ({})".format(",".join("?" for _ in ids)),
+                ids,
+            ).fetchall()
+            scored = []
+            for row in emb_rows:
+                score = _cosine(query_embedding, json.loads(row["vector_json"]))
+                scored.append((score, row["memory_id"]))
+            scored.sort(key=lambda x: (-x[0], x[1]))
+            vector_ranks = [memory_id for _, memory_id in scored[: limit * 4]]
+
+        fused = _rrf_merge(lexical_ranks, vector_ranks)
+        now = datetime.now(timezone.utc)
+        by_id = {m["memory_id"]: m for m in candidates}
+        results = []
+        for memory_id, parts in fused.items():
+            memory = by_id.get(memory_id)
+            if not memory:
+                continue
+            score = parts["rrf"]
+            created = datetime.strptime(memory["created_at"], "%Y-%m-%dT%H:%M:%S").replace(tzinfo=timezone.utc)
+            age_days = max(0.0, (now - created).total_seconds() / 86400.0)
+            recency_boost = 1.0 + max(0.0, (30 - age_days) / 300.0)
+            confidence_penalty = 1.0 if not memory["is_inference"] else max(0.4, float(memory["confidence"]))
+            score = score * recency_boost * confidence_penalty
+            results.append(MemorySearchResult(memory=memory, rank_score=score, components=parts))
+        results.sort(key=lambda r: (-r.rank_score, r.memory["created_at"], r.memory["memory_id"]))
+        return results[:limit]
+    finally:
+        if close:
+            conn.close()
+
+
+__all__ = [
+    "MemoryValidationError",
+    "MemorySearchResult",
+    "create_memory",
+    "update_memory",
+    "archive_memory",
+    "soft_delete_memory",
+    "attach_tags",
+    "attach_evidence_ref",
+    "get_memory",
+    "list_memories",
+    "upsert_embedding",
+    "search_memories",
+]

--- a/runtime/helpers.py
+++ b/runtime/helpers.py
@@ -559,6 +559,8 @@ def _build_status_report():
     openai_env_badge = "🟢" if runtime["env"]["has_openai_api_key"] else "🔴"
     cr_env_badge = "🟢" if runtime["env"]["has_cr_api_key"] else "🔴"
     schema_display = data.get("schema_display") or f"v{data.get('schema_version')}"
+    memory = data.get("contextual_memory") or {}
+    vec_badge = "🟢" if memory.get("sqlite_vec_enabled") else "🟡"
     lines = [
         "**Elixir Status**",
         f"🤖 Build: `{elixir_agent.BUILD_HASH}`",
@@ -569,6 +571,7 @@ def _build_status_report():
         f"📊 Data counts: raw payloads {data.get('counts', {}).get('raw_payload_count', 0)}, battle facts {data.get('counts', {}).get('battle_fact_count', 0)}, messages {data.get('counts', {}).get('message_count', 0)}, discord links {data.get('counts', {}).get('discord_links', 0)}",
         f"📥 Raw ingest: latest {((data.get('latest_raw_payload') or {}).get('endpoint') or 'n/a')} @ {_fmt_relative((data.get('latest_raw_payload') or {}).get('fetched_at'))}; endpoints {endpoint_summary}",
         f"🎯 Player intel backlog: {data.get('stale_player_intel_targets', 0)} stale target(s)",
+        f"🧠 Context memory: {memory.get('total', 0)} total ({memory.get('leader_notes', 0)} leader / {memory.get('inferences', 0)} inference / {memory.get('system_notes', 0)} system) | latest {_fmt_relative(memory.get('latest_memory_at'))} | vec {vec_badge}",
         f"{_status_badge(api.get('last_ok'))} CR API: last {(api.get('last_endpoint') or 'n/a')} ({api.get('last_entity_key') or '-'}) {_fmt_relative(api.get('last_call_at'))}; status {api.get('last_status_code') or 'n/a'}; {'ok' if api.get('last_ok') else 'error' if api.get('last_ok') is not None else 'n/a'}; {api.get('last_duration_ms') or 'n/a'}ms; total {api.get('call_count', 0)} calls / {api.get('error_count', 0)} errors / {api.get('consecutive_error_count', 0)} consecutive failures",
         f"{_status_badge(openai.get('last_ok'))} OpenAI: last {(openai.get('last_workflow') or 'n/a')} via {(openai.get('last_model') or 'n/a')} {_fmt_relative(openai.get('last_call_at'))}; {'ok' if openai.get('last_ok') else 'error' if openai.get('last_ok') is not None else 'n/a'}; {openai.get('last_duration_ms') or 'n/a'}ms; tokens p/c/t {openai.get('last_prompt_tokens') or 'n/a'}/{openai.get('last_completion_tokens') or 'n/a'}/{openai.get('last_total_tokens') or 'n/a'}; total {openai.get('call_count', 0)} calls / {openai.get('error_count', 0)} errors",
         f"🔐 Env: Discord {discord_badge}, OpenAI {openai_env_badge}, CR {cr_env_badge}",

--- a/storage/identity.py
+++ b/storage/identity.py
@@ -323,7 +323,11 @@ def get_system_status(conn=None):
             "(SELECT COUNT(*) FROM discord_links WHERE is_primary = 1) AS discord_links, "
             "(SELECT COUNT(*) FROM messages) AS message_count, "
             "(SELECT COUNT(*) FROM raw_api_payloads) AS raw_payload_count, "
-            "(SELECT COUNT(*) FROM member_battle_facts) AS battle_fact_count"
+            "(SELECT COUNT(*) FROM member_battle_facts) AS battle_fact_count, "
+            "(SELECT COUNT(*) FROM clan_memories) AS contextual_memory_count, "
+            "(SELECT COUNT(*) FROM clan_memories WHERE source_type = 'leader_note') AS contextual_leader_notes, "
+            "(SELECT COUNT(*) FROM clan_memories WHERE source_type = 'elixir_inference') AS contextual_inferences, "
+            "(SELECT COUNT(*) FROM clan_memories WHERE source_type = 'system') AS contextual_system_notes"
         ).fetchone()
         freshness = {
             "member_state_at": conn.execute(
@@ -337,6 +341,9 @@ def get_system_status(conn=None):
             ).fetchone()["ts"],
             "war_state_at": conn.execute(
                 "SELECT MAX(observed_at) AS ts FROM war_current_state"
+            ).fetchone()["ts"],
+            "contextual_memory_at": conn.execute(
+                "SELECT MAX(created_at) AS ts FROM clan_memories"
             ).fetchone()["ts"],
         }
         latest_raw = conn.execute(
@@ -352,6 +359,9 @@ def get_system_status(conn=None):
         stale_targets = len(get_player_intel_refresh_targets(limit=500, stale_after_hours=6, conn=conn))
         latest_signal = conn.execute(
             "SELECT signal_type, signal_date FROM signal_log ORDER BY signal_date DESC, signal_type ASC LIMIT 1"
+        ).fetchone()
+        memory_index_status = conn.execute(
+            "SELECT value FROM clan_memory_index_status WHERE key = 'sqlite_vec_enabled'"
         ).fetchone()
         roster_summary = get_clan_roster_summary(conn=conn)
         size_bytes = None
@@ -370,6 +380,14 @@ def get_system_status(conn=None):
             "current_season_id": current_season_id,
             "stale_player_intel_targets": stale_targets,
             "latest_signal": dict(latest_signal) if latest_signal else None,
+            "contextual_memory": {
+                "sqlite_vec_enabled": bool(memory_index_status and str(memory_index_status["value"]) == "1"),
+                "latest_memory_at": freshness["contextual_memory_at"],
+                "total": dict(counts).get("contextual_memory_count", 0),
+                "leader_notes": dict(counts).get("contextual_leader_notes", 0),
+                "inferences": dict(counts).get("contextual_inferences", 0),
+                "system_notes": dict(counts).get("contextual_system_notes", 0),
+            },
         }
     finally:
         if close:

--- a/tests/test_db_v2.py
+++ b/tests/test_db_v2.py
@@ -531,6 +531,9 @@ def test_get_system_status_summarizes_v2_data_layer():
         assert status["freshness"]["battle_fact_at"] is not None
         assert status["freshness"]["war_state_at"] is not None
         assert isinstance(status["raw_payloads_by_endpoint"], list)
+        assert "contextual_memory" in status
+        assert status["contextual_memory"]["total"] == 0
+        assert status["contextual_memory"]["leader_notes"] == 0
     finally:
         conn.close()
 

--- a/tests/test_elixir_channels.py
+++ b/tests/test_elixir_channels.py
@@ -642,6 +642,14 @@ def test_build_status_report_omits_job_schedule_section():
                 "signal_date": "2026-03-08",
             },
             "current_season_id": 130,
+            "contextual_memory": {
+                "sqlite_vec_enabled": True,
+                "latest_memory_at": "2026-03-08T10:20:00",
+                "total": 7,
+                "leader_notes": 3,
+                "inferences": 2,
+                "system_notes": 2,
+            },
         }),
         patch("elixir._app._member_role_grant_status", return_value={
             "configured": True,
@@ -657,6 +665,7 @@ def test_build_status_report_omits_job_schedule_section():
     assert "🛠️ Jobs:" not in report
     assert "Current war season id: 130" in report
     assert "Member role auto-grant: Manage Roles permission missing" in report
+    assert "🧠 Context memory: 7 total (3 leader / 2 inference / 2 system)" in report
 
 
 def test_on_message_hints_for_bare_clanops_clan_status_command():

--- a/tests/test_memory_system.py
+++ b/tests/test_memory_system.py
@@ -1,0 +1,271 @@
+import db
+from memory_reasoner import format_memory_for_response, package_prompt_context, summarize_member_memories
+from memory_store import (
+    MemoryValidationError,
+    archive_memory,
+    attach_evidence_ref,
+    attach_tags,
+    create_memory,
+    get_memory,
+    list_memories,
+    search_memories,
+    soft_delete_memory,
+    update_memory,
+    upsert_embedding,
+)
+
+
+def test_memory_schema_tables_exist_and_separate_from_authoritative_facts():
+    conn = db.get_connection(":memory:")
+    try:
+        tables = {
+            row["name"]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+        assert "memory_facts" in tables
+        assert "clan_memories" in tables
+
+        memory = create_memory(
+            body="Leader noted stronger attendance this week.",
+            source_type="leader_note",
+            is_inference=False,
+            confidence=1.0,
+            created_by="leader:jamie",
+            conn=conn,
+        )
+        facts = db.get_memory_facts("member", "999", conn=conn)
+        assert facts == []
+        assert get_memory(memory["memory_id"], conn=conn)["body"].startswith("Leader noted")
+    finally:
+        conn.close()
+
+
+def test_provenance_rules_and_retrieval_payload():
+    conn = db.get_connection(":memory:")
+    try:
+        item = create_memory(
+            body="Pattern suggests slight disengagement.",
+            source_type="elixir_inference",
+            is_inference=True,
+            confidence=0.7,
+            created_by="elixir",
+            scope="leadership",
+            conn=conn,
+        )
+        assert item["source_type"] == "elixir_inference"
+        assert item["is_inference"] == 1
+        assert item["confidence"] == 0.7
+
+        try:
+            create_memory(
+                body="bad",
+                source_type="elixir_inference",
+                is_inference=True,
+                confidence=1.0,
+                created_by="elixir",
+                conn=conn,
+            )
+            assert False, "expected validation error"
+        except MemoryValidationError:
+            pass
+    finally:
+        conn.close()
+
+
+def test_permissions_filters_and_lifecycle_controls():
+    conn = db.get_connection(":memory:")
+    try:
+        public = create_memory(
+            body="Public note",
+            source_type="leader_note",
+            is_inference=False,
+            confidence=1.0,
+            created_by="leader",
+            scope="public",
+            conn=conn,
+        )
+        leadership = create_memory(
+            body="Leadership-only note",
+            source_type="leader_note",
+            is_inference=False,
+            confidence=1.0,
+            created_by="leader",
+            scope="leadership",
+            conn=conn,
+        )
+        internal = create_memory(
+            body="Internal system tuning",
+            source_type="system",
+            is_inference=False,
+            confidence=1.0,
+            created_by="system",
+            scope="system_internal",
+            conn=conn,
+        )
+
+        public_view = list_memories(viewer_scope="public", conn=conn)
+        assert [m["memory_id"] for m in public_view] == [public["memory_id"]]
+
+        leader_view = list_memories(viewer_scope="leadership", conn=conn)
+        leader_ids = {m["memory_id"] for m in leader_view}
+        assert public["memory_id"] in leader_ids
+        assert leadership["memory_id"] in leader_ids
+        assert internal["memory_id"] not in leader_ids
+
+        system_view = list_memories(viewer_scope="system_internal", conn=conn)
+        system_ids = {m["memory_id"] for m in system_view}
+        assert internal["memory_id"] in system_ids
+
+        archive_memory(leadership["memory_id"], actor="leader", conn=conn)
+        assert get_memory(leadership["memory_id"], viewer_scope="leadership", conn=conn) is None
+
+        soft_delete_memory(public["memory_id"], actor="leader", conn=conn)
+        assert get_memory(public["memory_id"], viewer_scope="system_internal", conn=conn) is None
+    finally:
+        conn.close()
+
+
+def test_structured_filters_tags_evidence_and_audit_versions():
+    conn = db.get_connection(":memory:")
+    try:
+        member_id = db._ensure_member(conn, "#AAA111", name="Alpha")
+        item = create_memory(
+            body="Promotion after consistent war week.",
+            summary="Promotion candidate",
+            source_type="leader_note",
+            is_inference=False,
+            confidence=1.0,
+            created_by="leader",
+            member_id=member_id,
+            member_tag="#AAA111",
+            role="elder",
+            war_season_id="2026-s02",
+            war_week_id="2026-s02-w03",
+            event_type="promotion",
+            event_id="prom-123",
+            conn=conn,
+        )
+        attach_tags(item["memory_id"], ["promotion", "war"], actor="leader", conn=conn)
+        attach_evidence_ref(
+            item["memory_id"],
+            evidence_type="war_week",
+            evidence_ref="2026-s02-w03",
+            evidence_label="War week 3",
+            actor="leader",
+            conn=conn,
+        )
+        updated = update_memory(item["memory_id"], actor="leader", summary="Updated summary", conn=conn)
+        assert updated["summary"] == "Updated summary"
+        assert "promotion" in updated["tags"]
+        assert updated["evidence_refs"][0]["evidence_ref"] == "2026-s02-w03"
+
+        rows = list_memories(
+            viewer_scope="leadership",
+            filters={
+                "member_id": member_id,
+                "member_tag": "AAA111",
+                "role": "elder",
+                "war_season_id": "2026-s02",
+                "war_week_id": "2026-s02-w03",
+                "event_type": "promotion",
+                "event_id": "prom-123",
+                "scope": "leadership",
+                "source_type": "leader_note",
+                "is_inference": False,
+                "status": "active",
+            },
+            conn=conn,
+        )
+        assert len(rows) == 1
+
+        versions = conn.execute(
+            "SELECT COUNT(*) AS c FROM clan_memory_versions WHERE memory_id = ?",
+            (item["memory_id"],),
+        ).fetchone()["c"]
+        audits = conn.execute(
+            "SELECT COUNT(*) AS c FROM clan_memory_audit_log WHERE memory_id = ?",
+            (item["memory_id"],),
+        ).fetchone()["c"]
+        assert versions >= 1
+        assert audits >= 4
+    finally:
+        conn.close()
+
+
+def test_hybrid_search_rrf_and_fts_only_degraded_mode():
+    conn = db.get_connection(":memory:")
+    try:
+        a = create_memory(
+            body="Bravo showed war consistency and deck discipline.",
+            source_type="leader_note",
+            is_inference=False,
+            confidence=1.0,
+            created_by="leader",
+            conn=conn,
+        )
+        b = create_memory(
+            body="Charlie might need recognition for support role effort.",
+            source_type="elixir_inference",
+            is_inference=True,
+            confidence=0.8,
+            created_by="elixir",
+            conn=conn,
+        )
+
+        upsert_embedding(a["memory_id"], [1.0, 0.0, 0.0], conn=conn)
+        upsert_embedding(b["memory_id"], [0.0, 1.0, 0.0], conn=conn)
+
+        def embed_query(_):
+            return [1.0, 0.0, 0.0]
+
+        hybrid = search_memories("war consistency", embed_query=embed_query, conn=conn)
+        assert hybrid
+        assert hybrid[0].memory["memory_id"] == a["memory_id"]
+        assert "lexical_rank" in hybrid[0].components
+
+        fts_only = search_memories("recognition", embed_query=None, conn=conn)
+        assert fts_only
+        assert any(r.memory["memory_id"] == b["memory_id"] for r in fts_only)
+    finally:
+        conn.close()
+
+
+def test_summarization_and_safe_phrasing_helpers():
+    conn = db.get_connection(":memory:")
+    try:
+        member_id = db._ensure_member(conn, "#BBB222", name="Bravo")
+        leader = create_memory(
+            body="Leadership encouraged Bravo to keep consistency.",
+            source_type="leader_note",
+            is_inference=False,
+            confidence=1.0,
+            created_by="leader",
+            member_id=member_id,
+            conn=conn,
+        )
+        infer = create_memory(
+            body="Bravo may need motivation after two weaker cycles.",
+            source_type="elixir_inference",
+            is_inference=True,
+            confidence=0.45,
+            created_by="elixir",
+            member_id=member_id,
+            conn=conn,
+        )
+
+        packet = package_prompt_context(facts=[{"kind": "authoritative_fact"}], memories=[leader, infer])
+        assert len(packet["facts"]) == 1
+        assert len(packet["leadership_memories"]) == 1
+        assert len(packet["assistant_inferences"]) == 1
+
+        summary = summarize_member_memories(member_id, conn=conn)
+        assert summary.leadership_notes
+        assert summary.assistant_inferences
+        assert summary.open_questions
+
+        leader_text = format_memory_for_response(leader)
+        infer_text = format_memory_for_response(infer)
+        assert leader_text.startswith("Leadership noted")
+        assert "inferred" in infer_text and "confidence" in infer_text
+    finally:
+        conn.close()


### PR DESCRIPTION
### Motivation

- Introduce a contextual memory layer separate from authoritative `memory_facts`/`memory_episodes` to capture leadership notes, assistant inferences, and system records.
- Provide robust provenance, scope, and lifecycle controls so memories can be validated, audited, versioned, and safely soft-deleted/archived.
- Enable hybrid retrieval (FTS + embeddings) with Reciprocal Rank Fusion and graceful degraded behavior when vector/FTS features are unavailable.
- Surface contextual memory status in runtime diagnostics and provide summarization/phrasing helpers for downstream prompt packaging.

### Description

- Added a new `memory_store` module (`memory_store/__init__.py`) implementing create/update/archive/soft-delete, provenance validation, tag/evidence helpers, versioning/audit logging, FTS-based lexical search, embedding upsert, cosine scoring, and an RRF merge (`_rrf_merge`) with recency/confidence adjustments.
- Added a new `memory_reasoner` module (`memory_reasoner/__init__.py`) with `package_prompt_context`, summarization helpers, member/war summarizers, and `format_memory_for_response` safe-phrasing logic.
- Added DB migration `_migration_8` in `db/__init__.py` that creates `clan_memories` and related tables (`clan_memory_tags`, `clan_memory_tag_links`, `clan_memory_member_links`, `clan_memory_event_links`, `clan_memory_evidence_refs`, `clan_memory_versions`, `clan_memory_audit_log`, `clan_memory_embeddings`, `clan_memory_index_status`), an FTS5 virtual table with sync triggers (`clan_memories_fts`), indexes, and an attempt to create a `vec0` virtual table with a degraded-mode flag persisted to `clan_memory_index_status`.
- Updated runtime/status plumbing in `runtime/helpers.py` and `storage/identity.py` to report contextual memory counts and `sqlite_vec` status; added `IMPLEMENTATION_NOTES.md` documenting architecture and rollout considerations.
- Added comprehensive tests in `tests/test_memory_system.py` and updated existing tests (`tests/test_db_v2.py`, `tests/test_elixir_channels.py`) to validate schema presence, provenance rules, permissions, lifecycle, tagging/evidence, versions/audit log, hybrid search behavior, summarization, and runtime report text.

### Testing

- Ran the new memory system tests with `venv/bin/python -m pytest tests/test_memory_system.py -v` and they passed. 
- Ran updated DB/status tests with `venv/bin/python -m pytest tests/test_db_v2.py -v` and `venv/bin/python -m pytest tests/test_elixir_channels.py -v` and the modified assertions succeeded. 
- All added/changed automated tests completed without failures on the exercised matrix (FTS and degraded modes exercised via in-memory DB).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af9d601be483218f429ead96317cfb)