### PR TITLE
Elixir v4.5 "Coherent" — unified per-tick awareness loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ elixir.pid
 scripts/deck_conversations_eval*.json
 scripts/eval_all_requests_results*.json
 scripts/intent_router_eval_results*.json
+scripts/replay_awareness_report.md

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,48 @@ This file tracks shipped features and capabilities in reverse chronological orde
 
 ---
 
+## v4.5 — Coherent
+
+**Date:** 2026-04-14
+
+Elixir's proactive posting flipped from "one LLM call per detected signal" to "one agent turn per heartbeat that sees the full situation and decides what to say." The agent now investigates before posting, collapses related signals into single coherent posts, and is allowed to choose silence when nothing material has changed. Time and standing context attach to every post by default, not just to checkpoint triggers.
+
+### Unified Awareness Loop
+
+- New `runtime/situation.py` assembler builds one `Situation` payload per tick: time/phase, clan standing, all signals grouped by lane, hard-post-floor list, channel memory, and roster vitals.
+- New `awareness` workflow with the full read toolset (including `cr_api`) and an 8-round tool budget. The agent investigates before posting — streak posts cite specific opponents, member-join posts name the new player's deck and trophy count, war recaps name the contributors who carried the week.
+- Coherent timing: when 5 war signals (battle-day complete, week rollover, war complete, next practice phase active, etc.) all hit one tick, the agent emits one sequenced post instead of 5 separate ones racing each other.
+- Genuine silence: stale signals get caught at the agent layer (e.g. a `battle_hot_streak` signal whose live battle log shows the streak has since broken) and skipped with a logged reason.
+- Hard-post-floor fallback: signals like `member_join`, `war_battle_rank_change`, and `capability_unlock` are guaranteed to produce a post — if the agent omits one, the legacy per-signal path delivers it.
+
+### Channel Reorganization — `#trophy-road`
+
+- New `#trophy-road` channel (id `1493787763538133204`) carries volatile non-war battle activity: hot streaks, trophy pushes, Path of Legends promotions, and future Classic/Grand Challenge / Global Tournament / Ultimate Champion finishes.
+- `#player-progress` narrowed to durable milestones — arena unlocks, level-ups, card unlocks, badges, achievements. The mixing problem is gone.
+- Routing in `plan_signal_outcomes` updated to split `BATTLE_MODE_SIGNAL_TYPES` from `PROGRESSION_SIGNAL_TYPES`. Mixed batches split between lanes.
+
+### Time-Aware Posts in Every Lane
+
+- New `build_situation_time()` helper lifts hours-remaining, day index, phase, and colosseum awareness out of war-checkpoint scope.
+- The `_build_outcome_context` envelope now carries a `TIME / PHASE` block on every channel post — river-race posts can reference "9 hours left in Practice Day 2" without waiting for a 6h checkpoint to fire.
+
+### `channel_update` Gets Real Reach
+
+- The proactive `channel_update` workflow moved from `READ_TOOLS_NO_EXTERNAL` to the full `READ_TOOLS` set (now includes `cr_api`) with rounds bumped from 3 to 6. The system prompt now directs the model to investigate before posting.
+- Streak posts and rank-change posts can resolve specific opponents instead of restating the signal dict.
+
+### Tests & Eval
+
+- 18 new tests in `tests/test_awareness_loop.py` covering lane classification, situation assembly, fast-path skip, lane validation, and hard-post-floor fallback.
+- New replay harness (`scripts/replay_awareness.py`) replays real signals from the local DB through the awareness loop and validates lane discipline + hard-floor coverage. Used to evaluate quality before shipping.
+- Test suite: 518 → 536 passing.
+
+### Rollout
+
+- Cutover gated by `ELIXIR_AWARENESS_LOOP=true` env flag for one war cycle. Legacy per-signal router stays as the always-available fallback path. Flag will be removed once a clean war week is in.
+
+---
+
 ## v4.4 — Omnipresent
 
 **Date:** 2026-04-13

--- a/agent/core.py
+++ b/agent/core.py
@@ -29,8 +29,8 @@ def _get_build_hash():
 
 
 BUILD_HASH = _get_build_hash()
-RELEASE_VERSION = os.getenv("ELIXIR_RELEASE_VERSION", "v4.4")
-RELEASE_CODENAME = os.getenv("ELIXIR_RELEASE_CODENAME", "Omnipresent")
+RELEASE_VERSION = os.getenv("ELIXIR_RELEASE_VERSION", "v4.5")
+RELEASE_CODENAME = os.getenv("ELIXIR_RELEASE_CODENAME", "Coherent")
 RELEASE_LABEL = f'{RELEASE_VERSION} "{RELEASE_CODENAME}"'
 
 _client = None

--- a/agent/prompts.py
+++ b/agent/prompts.py
@@ -87,8 +87,13 @@ def _proactive_channel_system(channel_name: str, subagent_key: str, *, leadershi
         purpose,
         knowledge,
         channel_context,
-        "You have tools available to look up the full roster, member profiles, recent form, deck data, war status, and long-term trend summaries. "
-        "Use them if you want more context before writing your post.\n\n"
+        "You have tools available to look up the full roster, member profiles, recent form, deck data, war status, and long-term trend summaries.\n\n"
+        "**Investigate before you post.** When a signal names a specific player and the post hinges on *who they were beating* or *what they were facing*, "
+        "use `cr_api(aspect='player_battles', tag='#TAG')` to pull their recent matches, then `cr_api(aspect='player', tag='#TAG')` on a notable opponent if it sharpens the post. "
+        "When a rank changes or a new rival appears, scout them with `cr_api(aspect='clan', tag='#TAG')` or `cr_api(aspect='clan_war', tag='#TAG')`. "
+        "External lookups are capped at 5 per turn — that is plenty for one streak post or one rivalry scout. "
+        "Posts that cite specific evidence (opponent trophies, opponent deck archetype, rival clan size) read sharper than posts that restate the signal dict. "
+        "Only skip the lookup when the signal is fully self-explanatory (e.g. a card unlock, a rank move you already have all the numbers for).\n\n"
         f"You are writing for the `{subagent_key}` channel subagent. "
         "Stay in that lane. Do not drift into unrelated channel jobs.\n\n"
         f"You may only use {memory_scope} durable memory context when it is provided. "
@@ -107,6 +112,22 @@ def _proactive_channel_system(channel_name: str, subagent_key: str, *, leadershi
         '"member_tags": [], "member_names": [], "summary": "one sentence", '
         '"content": "full Discord-ready markdown post OR [\"post 1\", \"post 2\"]", "metadata": {}}\n\n'
         "Or respond with exactly: null\n\nif the signals are genuinely not worth posting about.",
+    )
+
+
+def _awareness_system():
+    """System prompt for the per-tick awareness loop (Phase 4).
+
+    Loads the awareness subagent prompt that defines lane rules, output
+    schema, and the "decide what to say" framing. Identity + knowledge
+    blocks come along so the agent can reason in voice.
+    """
+    return _build_system_prompt(
+        prompts.identity_block(),
+        prompts.knowledge_block(),
+        prompts.subagent_prompt("awareness"),
+        _discord_formatting_guidance(),
+        _discord_emoji_guidance(),
     )
 
 
@@ -643,4 +664,5 @@ __all__ = [
     "_promote_system",
     "_weekly_digest_system",
     "_event_system",
+    "_awareness_system",
 ]

--- a/agent/tool_policy.py
+++ b/agent/tool_policy.py
@@ -7,8 +7,10 @@ _WRITE_TOOL_NAMES = {"update_member", "save_clan_memory"}
 EXTERNAL_LOOKUP_TOOL_NAMES = {"cr_api"}
 
 # Workflows that don't need the conversational CR bridge — they're one-shot
-# observation/formatting jobs with narrow, local-only scopes.
-_NO_EXTERNAL_LOOKUP_WORKFLOWS = {"observe", "channel_update", "reception", "roster_bios"}
+# observation/formatting jobs with narrow, local-only scopes. channel_update
+# is intentionally NOT here: as of v4.5 the proactive channel poster gets
+# cr_api so it can investigate (e.g. resolve streak opponents) before posting.
+_NO_EXTERNAL_LOOKUP_WORKFLOWS = {"observe", "reception", "roster_bios"}
 
 TOOL_DEFINITIONS = []
 for _tool in TOOLS:
@@ -44,7 +46,7 @@ INTERACTIVE_READ_TOOLS = READ_TOOLS
 
 TOOLSETS_BY_WORKFLOW = {
     "observe": READ_TOOLS_NO_EXTERNAL,
-    "channel_update": READ_TOOLS_NO_EXTERNAL,
+    "channel_update": READ_TOOLS,
     "channel_update_leadership": READ_TOOLS,
     "interactive": INTERACTIVE_READ_TOOLS,
     "clanops": ALL_TOOLS,
@@ -52,15 +54,22 @@ TOOLSETS_BY_WORKFLOW = {
     "roster_bios": READ_TOOLS_NO_EXTERNAL,
     "deck_review": INTERACTIVE_READ_TOOLS,
     "intel_report": INTEL_REPORT_TOOLS,
+    # Awareness loop (Phase 4): one agent turn per heartbeat that sees the full
+    # situation and emits a post plan. Gets the full read-tool set so it can
+    # investigate before posting.
+    "awareness": READ_TOOLS,
 }
 
 MAX_ROUNDS_BY_WORKFLOW = {
     "clanops": 5,
-    "channel_update_leadership": 5,
+    "channel_update_leadership": 6,
     "interactive": 3,
     "observation": 3,
     "observe": 3,
-    "channel_update": 3,
+    # channel_update gets real reach as of v4.5 — investigate streak opponents,
+    # scout rivals, check standings — before posting. 6 rounds buys ~5 tool
+    # calls plus the final answer turn.
+    "channel_update": 6,
     "reception": 0,
     "roster_bios": 3,
     # deck_review chains are unusually long: war reconstruction → losses
@@ -71,6 +80,10 @@ MAX_ROUNDS_BY_WORKFLOW = {
     # intel_report fans out across 4 opponents (~2 tool calls each) plus the
     # initial clan_war confirmation; 15 leaves headroom for retries.
     "intel_report": 15,
+    # awareness loop: one situation in, possibly N posts out. Budget for a
+    # couple of investigative tool calls (cr_api lookups for streak opponents,
+    # rival scouting) plus the final post-plan answer turn.
+    "awareness": 8,
 }
 
 RESPONSE_SCHEMAS_BY_WORKFLOW = {
@@ -83,4 +96,6 @@ RESPONSE_SCHEMAS_BY_WORKFLOW = {
     "roster_bios": {"required": ["intro", "members"]},
     "deck_review": {"required": ["event_type", "summary", "content"]},
     "intel_report": {"required": ["event_type", "summary", "content"]},
+    # awareness emits a post plan: zero or more posts, each routed to a channel.
+    "awareness": {"required": ["posts"]},
 }

--- a/agent/workflows.py
+++ b/agent/workflows.py
@@ -14,6 +14,7 @@ from agent.core import (
 )
 from agent.chat import _clan_context, _format_memory_context, _format_recent_posts, _parse_response
 from agent.prompts import (
+    _awareness_system,
     _channel_subagent_system,
     _clanops_system,
     _deck_review_system,
@@ -357,6 +358,31 @@ def generate_channel_update(channel_name, subagent_key, context, *,
         workflow=workflow,
         allowed_tools=TOOLSETS_BY_WORKFLOW[workflow],
         response_schema=RESPONSE_SCHEMAS_BY_WORKFLOW[workflow],
+        strict_json=True,
+    )
+
+
+def run_awareness_tick(situation: dict):
+    """Run one awareness-loop turn. Receives the assembled Situation, returns
+    a structured post plan: ``{"posts": [...], "skipped_reason": "..."}``.
+
+    Phase 4 of the unified agentic awareness loop. Replaces N per-signal
+    ``generate_channel_update`` calls with one agent turn that sees the full
+    situation and decides what (if anything) to say where.
+    """
+    user_msg = (
+        "Here is the current Situation. Decide what, if anything, to post and "
+        "where, following the lane rules in your system prompt. Silence is an "
+        "allowed outcome. Hard-post-floor signals (in `hard_post_signals`) "
+        "must be addressed.\n\n"
+        f"```json\n{json.dumps(situation, indent=2, default=str)}\n```\n"
+    )
+    return _chat_with_tools(
+        _awareness_system(),
+        user_msg,
+        workflow="awareness",
+        allowed_tools=TOOLSETS_BY_WORKFLOW["awareness"],
+        response_schema=RESPONSE_SCHEMAS_BY_WORKFLOW["awareness"],
         strict_json=True,
     )
 
@@ -876,6 +902,7 @@ __all__ = [
     "observe_and_post",
     "generate_channel_update",
     "generate_intel_report",
+    "run_awareness_tick",
     "respond_in_reception",
     "respond_in_channel",
     "respond_in_deck_review",

--- a/heartbeat/__init__.py
+++ b/heartbeat/__init__.py
@@ -52,6 +52,7 @@ from heartbeat._war import (
     _detect_war_rank_changes_for_pair,
     _detect_war_rollovers_for_pair,
     _detect_war_season_completion_for_pair,
+    build_situation_time,
     detect_war_battle_checkpoints,
     detect_war_battle_final_hours,
     detect_war_champ_update,
@@ -222,6 +223,8 @@ __all__ = [
     "detect_war_season_completion",
     "detect_war_completion",
     "detect_war_champ_update",
+    # Situation helpers
+    "build_situation_time",
     # Pipeline
     "ingest_live_war_state",
     "detect_war_signals_from_storage",

--- a/heartbeat/_war.py
+++ b/heartbeat/_war.py
@@ -561,6 +561,49 @@ def detect_war_week_complete(completion_signals, conn=None):
     return signals
 
 
+def build_situation_time(*, war_day_state=None, conn=None):
+    """Compact time/phase awareness for any channel post.
+
+    Lifts hours-remaining, day index, phase, and colosseum awareness out of
+    checkpoint-only scope so non-checkpoint posts (streaks, milestones,
+    standings) can reason about *when* in the war week they're firing.
+    Returns ``None`` when there is no current war state.
+    """
+    if war_day_state is None:
+        war_day_state = db.get_current_war_day_state(conn=conn) or {}
+    if not war_day_state:
+        return None
+
+    phase = war_day_state.get("phase")
+    period_type = war_day_state.get("period_type")
+    day_number = war_day_state.get("day_number")
+    day_total = war_day_state.get("day_total")
+    time_left_seconds = war_day_state.get("time_left_seconds")
+    hours_remaining_in_day = (
+        max(0, time_left_seconds) // 3600 if time_left_seconds is not None else None
+    )
+    is_final_battle_day = (
+        phase == "battle"
+        and day_number is not None
+        and day_total is not None
+        and day_number == day_total
+    )
+
+    return {
+        "phase": phase,
+        "phase_display": war_day_state.get("phase_display"),
+        "day_number": day_number,
+        "day_total": day_total,
+        "hours_remaining_in_day": hours_remaining_in_day,
+        "time_left_text": war_day_state.get("time_left_text"),
+        "is_final_battle_day": is_final_battle_day,
+        "is_colosseum_week": is_colosseum_week(period_type),
+        "season_id": war_day_state.get("season_id"),
+        "week": war_day_state.get("week"),
+        "race_completed": bool(war_day_state.get("race_completed")),
+    }
+
+
 def detect_war_season_completion(conn=None):
     states = db.get_recent_live_war_states(limit=2, conn=conn)
     if len(states) < 2:

--- a/prompts.py
+++ b/prompts.py
@@ -51,6 +51,14 @@ CHANNEL_SUBAGENT_CONFIG = {
         "memory_scope": "public",
         "durable_memory_enabled": True,
     },
+    "trophy-road": {
+        "workflow": "channel_update",
+        "tool_policy": "read_only",
+        "reply_policy": "disabled",
+        "singleton": True,
+        "memory_scope": "public",
+        "durable_memory_enabled": True,
+    },
     "clan-events": {
         "workflow": "channel_update",
         "tool_policy": "read_only",
@@ -107,6 +115,7 @@ SUBAGENT_ALIASES = {
     "promotion": "promote-the-clan",
     "river_race": "river-race",
     "player_progress": "player-progress",
+    "trophy_road": "trophy-road",
     "clan_events": "clan-events",
     "clanops": "leader-lounge",
     "ask_elixir": "ask-elixir",

--- a/prompts/DISCORD.md
+++ b/prompts/DISCORD.md
@@ -72,14 +72,35 @@ ToolPolicy: read_only
 MemoryScope: public
 DurableMemory: true
 
-Elixir's player milestone and progression stream.
+Elixir's durable player milestone stream.
 
-- Use this channel for player milestones, progression, arena jumps, card upgrades, badge/mastery moments, and standout growth.
+- Use this channel for *durable* milestones: arena jumps, level-ups, card unlocks (legendary, champion), card-level milestones, badge unlocks, achievements.
+- These are the moments that belong in the long-term clan story — celebratory and infrequent.
 - Keep the spotlight on the player and why the moment matters.
 - It is okay for Elixir to be a little more chatty here when the milestone is genuinely exciting.
 - Legendary unlocks and new Trophy Road arenas are especially notable moments.
 - Avoid turning routine noise into a post.
+- *Volatile* battle-mode activity (hot streaks, trophy pushes, Path of Legend promotions) belongs in #trophy-road, not here.
 - This is not the place for war coordination or leadership notes.
+
+## #trophy-road
+
+ID: 1493787763538133204
+Subagent: trophy-road
+Workflow: channel_update
+ToolPolicy: read_only
+MemoryScope: public
+DurableMemory: true
+
+Elixir's volatile battle-mode activity stream.
+
+- Use this channel for non-war battle-mode activity: hot streaks, trophy pushes, Path of Legends promotions, ladder moments.
+- Future Classic/Grand Challenge finishes, Global Tournament placements, evolution unlocks, and Ultimate Champion belong here too.
+- This is narrative and discardable — today's push, tonight's streak. Not a long-term archive.
+- Keep posts sharp and grounded in actual evidence: who they were beating, what trophies on the line, what archetype faced.
+- Use cr_api to look up the opponents in a streak — names and trophy levels make the post.
+- Durable milestones (level-ups, card unlocks, badges) belong in #player-progress, not here.
+- No war coordination — that lives in #river-race.
 
 ## #clan-events
 

--- a/prompts/subagents/awareness.md
+++ b/prompts/subagents/awareness.md
@@ -1,0 +1,95 @@
+# Elixir — Awareness Loop
+
+I am the clan's awareness loop. Once per heartbeat tick I get a single picture of the situation — what's happened since the last tick, where in the war week we are, and what each channel has heard from me recently — and I decide what, if anything, is worth saying.
+
+## My Job
+
+The framing is *not* "write a post for signal X." The framing is: **here is the situation; what posts (if any) are warranted, and on which channels?**
+
+Silence is allowed. If nothing material has changed and no clock pressure is real, I post nothing.
+
+## What I See Each Tick
+
+The user message contains a structured `Situation` object:
+
+- `time` — current war phase, day index, hours remaining, colosseum flag.
+- `standing` — clan rank, fame, deficit-to-leader, pace status, engagement.
+- `signals_by_lane` — raw signals since the last tick, grouped by lane: `war`, `battle_mode`, `milestone`, `clan_event`, `leadership`, `system`.
+- `channel_memory` — for each channel, what I've already posted recently (so I don't repeat angles).
+- `roster_vitals` — compact 20-row most-active-this-week table (a scouting anchor; not for verbatim posting).
+- `hard_post_signals` — signals that *must* produce a post; I choose framing, not existence.
+
+## Channel Lanes
+
+| Channel | Scope |
+|---|---|
+| **#river-race** | Clan Wars only — `war_*` signals, race momentum, day transitions, week complete |
+| **#trophy-road** | Volatile non-war battle activity — hot streaks, trophy pushes, Path of Legends promotions |
+| **#player-progress** | Durable milestones — arena changes, level-ups, card unlocks, badges, achievements |
+| **#clan-events** | Roster — joins, leaves, promotions, anniversaries, birthdays |
+| **#leader-lounge** | Leadership-only — ops notes, rank swings, at-risk, kicks |
+| **#announcements** | System / weekly — capability unlocks, weekly recap |
+
+A war post does not ship to #trophy-road. A milestone does not ship to #river-race. The lanes are strict.
+
+**#announcements is off-limits to the awareness loop except for `capability_unlock` signals.** The weekly clan recap is published by a separate dedicated workflow — never duplicate a war or milestone post into #announcements thinking "this is also a story." If a war recap belongs anywhere, it belongs in #river-race; do not also fan it out to #announcements.
+
+## Investigate Before You Post — Required, Not Optional
+
+I have `cr_api` and the full read-tool set. For these signal types, I MUST call a tool before posting:
+
+- `battle_hot_streak`, `battle_trophy_push`, `path_of_legend_promotion` — call `cr_api(aspect="player_battles", tag="<the player's tag>")` to see *who* they were beating and what archetypes faced. The post leads with that evidence ("three of those against 7K+ trophy opponents on a 3.2-elixir cycle").
+- `war_battle_rank_change`, new opponent appears in standings — call `cr_api(aspect="clan", tag="<opponent tag>")` or `cr_api(aspect="clan_war", tag="<our tag>")` to scout.
+- Any signal where the post hinges on detail not present in the signal dict.
+
+A post that just restates the signal dict ("gooba is on a 7-win streak, nice") is a failure. The bar is: tell members something they could not see by opening the game themselves. External lookups are capped at 5 per turn — that is plenty.
+
+For card-unlock / arena-change / member-join signals the signal dict is usually self-sufficient and a tool call is unnecessary.
+
+When `channel_memory` shows I covered the same angle three hours ago, I either skip or reframe. I do not repeat myself.
+
+## Hard-Post Floors
+
+`hard_post_signals` lists signals that are guaranteed to produce a post. These include `war_battle_rank_change`, `member_join`, `member_leave`, `capability_unlock`, `war_week_complete`, `war_season_complete`. I choose how to frame them and which channel they land on (within the lane rules above) — but every signal in `hard_post_signals` MUST appear in my output.
+
+## Output Schema
+
+I respond with JSON only:
+
+```json
+{
+  "posts": [
+    {
+      "channel": "river-race",
+      "leads_with": "war",
+      "tone": "tactical",
+      "summary": "one sentence",
+      "content": "Discord-ready markdown, or [\"part 1\", \"part 2\"]",
+      "covers_signal_keys": ["..."],
+      "member_tags": [],
+      "member_names": []
+    }
+  ],
+  "skipped_reason": "optional one-line note when posts is empty"
+}
+```
+
+`posts` is allowed to be empty.
+
+`channel` MUST be one of: `river-race`, `trophy-road`, `player-progress`, `clan-events`, `leader-lounge`, `announcements`. No other values.
+
+`leads_with` MUST be one of: `war`, `battle_mode`, `milestone`, `clan_event`, `leadership`, `system`. No other values. Map each post by what it leads with:
+- War / race / standings → `war` (lane: river-race or leader-lounge)
+- Hot streak / trophy push / Path of Legends → `battle_mode` (lane: trophy-road)
+- Arena change / level-up / card unlock / badge / achievement → `milestone` (lane: player-progress)
+- Member join / leave / promotion / birthday / anniversary → `clan_event` (lane: clan-events or leader-lounge)
+- Inactive members / leadership-only → `leadership` (lane: leader-lounge)
+- Capability unlocks / weekly recap → `system` (lane: announcements)
+
+`covers_signal_keys` MUST list the `signal_key` field of every signal this post addresses. Each signal in `signals_by_lane` and `hard_post_signals` carries a `signal_key` — copy those values verbatim. The delivery layer uses this to confirm hard-post-floor coverage and dedupe.
+
+Each post should carry one coherent topic beat. If two posts on the same channel would be redundant, combine them. If two beats on different channels are about genuinely different things, that's fine — emit both.
+
+## Voice
+
+Each channel has its own persona file (river-race, trophy-road, player-progress, etc.). I draft the body in *that channel's* voice, not in a generic narrator voice. The lane choice picks the voice.

--- a/prompts/subagents/player-progress.md
+++ b/prompts/subagents/player-progress.md
@@ -2,7 +2,9 @@
 
 Someone in the clan just did something worth noticing. I notice it.
 
-This channel is where real player milestones get recognized — not every badge tick, but the moments that actually mean something to a Clash Royale player. A Legendary unlock. A new Trophy Road arena. A big level jump that took months to get to. I call those out with energy, because they earned it.
+This channel is where *durable* player milestones get recognized — not every badge tick, but the moments that actually mean something to a Clash Royale player. A Legendary unlock. A new Trophy Road arena. A big level jump that took months to get to. I call those out with energy, because they earned it.
+
+Volatile battle-mode activity — hot streaks, Path of Legends promotions, trophy pushes — lives in #trophy-road, not here. This lane is for the moments that belong in the long-term clan story.
 
 ## My Role Here
 
@@ -21,6 +23,10 @@ Or an arena climb:
 > "King Levy crossed into Challenger II. That is a real step — the competition gets sharper from here."
 
 Specific. Grounded. Proud of the player without being hollow about it.
+
+## Time Awareness
+
+The context envelope includes a `TIME / PHASE` block (war phase, day index, hours remaining, colosseum flag). For milestones, this is *background* — don't lead with it. But if a player hits a big milestone *during* a battle day push, you can let it land that way ("on a Battle Day 3 push, no less"). Don't force the war frame onto a milestone that has nothing to do with the war.
 
 ## What Belongs Here
 

--- a/prompts/subagents/river-race.md
+++ b/prompts/subagents/river-race.md
@@ -37,6 +37,10 @@ What members cannot easily see — and what I lead with:
 
 A good test for every post: would this tell a member something they would not already know from opening the game? If not, it is not worth the interruption. Raw state can appear as brief framing context, but it is never the point.
 
+## Time Awareness
+
+Every context envelope includes a `TIME / PHASE` block with `phase`, `day_number`/`day_total`, `hours_remaining_in_day`, `is_final_battle_day`, and `is_colosseum_week`. Use it narratively. "Battle Day 2, six hours left, 180 fame back" lands harder than "the race is going." Don't wait for a checkpoint signal to fire to reference the clock — if the clock matters to the post, name it.
+
 ## Voice
 
 Concise. Situational. Confident. More match commentator than announcement feed.

--- a/prompts/subagents/trophy-road.md
+++ b/prompts/subagents/trophy-road.md
@@ -1,0 +1,57 @@
+# Elixir — Trophy Road Lane
+
+Someone is pushing right now. I notice the push.
+
+This channel is the volatile, narrative side of battle activity — Trophy Road climbs, Path of Legends promotions, hot streaks outside of war. Not durable milestones (those go to #player-progress). Not war coordination (that goes to #river-race). The shape of *what is happening tonight* in non-war battle modes.
+
+## My Role Here
+
+Frame the push. A streak isn't "8-in-a-row" — it's "8-in-a-row, three of those against 7K+ opponents on a 3.2-elixir cycle deck." A trophy push isn't "+140 trophies" — it's "+140 trophies, 30 short of a season best."
+
+Posts here are discardable tomorrow. That's fine. Today's push matters today.
+
+## Investigate Before You Post
+
+I have `cr_api` available and should use it. When a streak names a player, I should look up their recent battles to see *who* they were beating and *what* archetypes they faced. That detail is what makes the post worth reading.
+
+- `cr_api(aspect='player_battles', tag='#TAG')` — pull the player's recent matches.
+- `cr_api(aspect='player', tag='#OPP')` — scout a notable opponent if it sharpens the post.
+
+External lookups are capped at 5 per turn. That is plenty for one streak post.
+
+## Voice
+
+Sharp, present-tense, narrative. Closer to live commentary than recap. Less hype than #player-progress — these are not lifetime achievements, they are the texture of a session. The right note is "noticing" rather than "celebrating."
+
+Sample shape for a hot streak:
+> "Raquaza is on 8-in-a-row in Trophy Road. Three of those came against 7K+ trophy opponents — the kind of run that says the deck is dialed in tonight."
+
+Sample shape for a Path of Legends promotion:
+> "King Levy just hit Champion II in Path of Legends. The grind through Master III took two weeks; this one took two nights."
+
+Or a trophy push:
+> "Sarah is up 140 trophies this session — 30 short of her season high. The deck is a Mortar cycle variant and it is finding gaps."
+
+## What Belongs Here
+
+- Hot streaks (consecutive wins) outside of war.
+- Trophy pushes — meaningful trophy gains in a session.
+- Path of Legends promotions (Master/Champion ranks).
+- Future: Classic/Grand Challenge finishes, Global Tournament placements, evolution unlocks, Ultimate Champion.
+
+## What Doesn't Belong Here
+
+- War battle activity — #river-race.
+- Durable milestones (level-ups, card unlocks, badges, achievements) — #player-progress.
+- Arena changes — #player-progress (those are the durable trophy-road milestones; this lane is about momentum, not the arena post itself).
+
+## Time Awareness
+
+The context envelope includes a `TIME / PHASE` block. Battle-mode activity is mostly orthogonal to the war calendar, so don't force a war frame onto a Trophy Road post. The exception: when someone is pushing trophies *during* a battle day push, that's a fair note ("on a Battle Day 2 push, no less").
+
+## Guardrails
+
+- Don't restate the signal dict — interpret it with evidence.
+- One clear beat per post.
+- No multi-paragraph posts. This is the texture of a moment, not a deep dive.
+- No war coordination, no leadership content, no recruiting copy here.

--- a/runtime/channel_subagents.py
+++ b/runtime/channel_subagents.py
@@ -8,19 +8,28 @@ import prompts
 from memory_store import list_memories
 from storage.contextual_memory import upsert_summary_memory
 
+# Durable milestones — celebratory and infrequent. Belong in the long-term
+# clan story. Routed to #player-progress.
 PROGRESSION_SIGNAL_TYPES = {
     "arena_change",
     "player_level_up",
     "career_wins_milestone",
-    "path_of_legend_promotion",
     "new_card_unlocked",
     "new_champion_unlocked",
     "card_level_milestone",
     "badge_earned",
     "badge_level_milestone",
     "achievement_star_milestone",
+}
+
+# Volatile battle-mode activity outside of war — hot streaks, trophy pushes,
+# Path of Legends promotions. Discardable tomorrow. Routed to #trophy-road.
+# Future Classic/Grand Challenge finishes, Global Tournament placements, and
+# evolution/Ultimate Champion unlocks join this set additively.
+BATTLE_MODE_SIGNAL_TYPES = {
     "battle_hot_streak",
     "battle_trophy_push",
+    "path_of_legend_promotion",
 }
 
 OPTIONAL_PROGRESSION_SIGNAL_TYPES = {
@@ -78,8 +87,15 @@ def signal_routing_summary() -> list[dict]:
             ],
         },
         {
+            "family": "battle_mode",
+            "match": "all signals in the batch are battle-mode signals (hot streak, trophy push, PoL promotion)",
+            "targets": [
+                {"subagent": "trophy-road", "intent": "battle_mode_update", "required": True},
+            ],
+        },
+        {
             "family": "progression",
-            "match": "all signals in the batch are non-optional progression signals",
+            "match": "all signals in the batch are non-optional durable milestones",
             "targets": [
                 {"subagent": "player-progress", "intent": "player_progress", "required": True},
             ],
@@ -166,6 +182,10 @@ def is_war_signal(signal: dict) -> bool:
 
 def is_progression_signal(signal: dict) -> bool:
     return (signal or {}).get("type") in PROGRESSION_SIGNAL_TYPES
+
+
+def is_battle_mode_signal(signal: dict) -> bool:
+    return (signal or {}).get("type") in BATTLE_MODE_SIGNAL_TYPES
 
 
 def is_tournament_signal(signal: dict) -> bool:
@@ -284,8 +304,23 @@ def plan_signal_outcomes(signals: list[dict]) -> list[dict]:
         add("player-progress", "player_progress", required=False)
         return outcomes
 
+    if all(is_battle_mode_signal(signal) for signal in signals):
+        add("trophy-road", "battle_mode_update", required=True)
+        return outcomes
+
     if all(is_progression_signal(signal) for signal in signals):
         add("player-progress", "player_progress", required=True)
+        return outcomes
+
+    # Mixed durable + battle-mode batches: split so each lane gets only its kind.
+    if all(
+        is_progression_signal(signal) or is_battle_mode_signal(signal)
+        for signal in signals
+    ):
+        if any(is_progression_signal(signal) for signal in signals):
+            add("player-progress", "player_progress", required=True)
+        if any(is_battle_mode_signal(signal) for signal in signals):
+            add("trophy-road", "battle_mode_update", required=True)
         return outcomes
 
     if any((signal.get("type") == "member_join") for signal in signals):
@@ -354,7 +389,9 @@ def maybe_upsert_signal_memory(*, source_signal_key: str, signal_type: str, body
 
 
 __all__ = [
+    "BATTLE_MODE_SIGNAL_TYPES",
     "build_subagent_memory_context",
+    "is_battle_mode_signal",
     "is_progression_signal",
     "is_war_signal",
     "maybe_upsert_signal_memory",

--- a/runtime/jobs/_core.py
+++ b/runtime/jobs/_core.py
@@ -47,6 +47,7 @@ from runtime.system_signals import queue_startup_system_signals
 from runtime.jobs._signals import (
     _channel_config_by_key,
     _deliver_signal_group,
+    _deliver_signal_group_via_awareness,
     _format_weekly_recap_post,
     _load_live_clan_context,
     _mark_delivered_signals,
@@ -57,6 +58,13 @@ from runtime.jobs._signals import (
     _publish_pending_system_signal_updates,
     _strip_weekly_recap_header,
 )
+
+
+def _awareness_loop_enabled() -> bool:
+    """Phase 4 cutover gate. Default off; flip to ``true`` to route ticks
+    through the unified awareness agent. When false, the legacy per-signal
+    router runs unchanged."""
+    return os.environ.get("ELIXIR_AWARENESS_LOOP", "").strip().lower() in {"1", "true", "yes", "on"}
 from runtime.jobs._intel import _clan_wars_intel_report
 from runtime.jobs._site import (
     _normalize_poap_kings_publish_result,
@@ -308,13 +316,21 @@ async def _clan_awareness_tick():
         war = tick_result.war
 
         failed = 0
-        for signal in signals:
-            if not await _deliver_signal_group([signal], clan, war):
-                failed += 1
-                log.warning(
-                    "clan_awareness signal delivery failed type=%s tag=%s",
-                    signal.get("type"), signal.get("tag"),
-                )
+        if _awareness_loop_enabled():
+            # Phase 4: one agent turn sees all signals together and emits a
+            # post plan. Hard-post-floor signals fall back to per-signal on
+            # omission so coverage is still guaranteed.
+            ok = await _deliver_signal_group_via_awareness(signals, clan, war)
+            if not ok:
+                failed = len(signals)
+        else:
+            for signal in signals:
+                if not await _deliver_signal_group([signal], clan, war):
+                    failed += 1
+                    log.warning(
+                        "clan_awareness signal delivery failed type=%s tag=%s",
+                        signal.get("type"), signal.get("tag"),
+                    )
 
         await _revoke_member_role_for_leavers(signals)
 
@@ -373,9 +389,12 @@ async def _war_awareness_tick():
         war = detection_result.war
 
         delivered_ok = True
-        for signal_batch in _observation_signal_batches(signals):
-            batch_ok = await _deliver_signal_group(signal_batch, clan, war)
-            delivered_ok = delivered_ok and batch_ok
+        if _awareness_loop_enabled():
+            delivered_ok = await _deliver_signal_group_via_awareness(signals, clan, war)
+        else:
+            for signal_batch in _observation_signal_batches(signals):
+                batch_ok = await _deliver_signal_group(signal_batch, clan, war)
+                delivered_ok = delivered_ok and batch_ok
 
         if not delivered_ok:
             runtime_status.mark_job_failure("war_awareness", "one or more war signal batches failed")

--- a/runtime/jobs/_signals.py
+++ b/runtime/jobs/_signals.py
@@ -5,6 +5,8 @@ __all__ = [
     "_channel_config_by_key", "_signal_group_needs_recap_memory",
     "_build_outcome_context", "_mark_signal_group_completed", "_post_signal_memory",
     "_deliver_signal_outcome", "_deliver_signal_group",
+    "_deliver_awareness_post", "_deliver_awareness_post_plan",
+    "_deliver_signal_group_via_awareness",
     "_strip_weekly_recap_header", "_format_weekly_recap_post",
     "_observation_signal_batches", "_progression_signal_batches",
     "_system_signal_updates", "_store_recap_memories_for_signal_batch",
@@ -247,6 +249,21 @@ def _build_outcome_context(outcome, signals, clan, war):
         "Signals:",
         json.dumps(signals or [], indent=2, default=str),
     ]
+    # Ambient time/phase awareness — available to every channel, not just war
+    # checkpoints. Lets non-checkpoint posts narrate "six hours left, 180 fame
+    # back" without waiting for a tripwire to fire.
+    try:
+        from heartbeat import build_situation_time
+        situation_time = build_situation_time()
+    except Exception:
+        log.warning("build_situation_time failed", exc_info=True)
+        situation_time = None
+    if situation_time:
+        lines.extend([
+            "",
+            "=== TIME / PHASE (current ambient context, use narratively) ===",
+            json.dumps(situation_time, indent=2, default=str),
+        ])
     if channel_key == "river-race":
         lines.extend([
             "",
@@ -287,6 +304,17 @@ def _build_outcome_context(outcome, signals, clan, war):
             insight_lines = _build_player_insight_context(tag)
             if insight_lines:
                 lines.extend(["", "=== PLAYER CONTEXT (use to interpret the achievement) ==="] + insight_lines)
+    elif channel_key == "trophy-road":
+        lines.extend([
+            "",
+            "Focus on the *push happening right now* — non-war battle activity. Investigate before you post: when a streak names a player, "
+            "use cr_api(aspect='player_battles') to see who they were beating, then cr_api(aspect='player') on a notable opponent if it sharpens the post.",
+        ])
+        tag = first.get("tag")
+        if tag:
+            insight_lines = _build_player_insight_context(tag)
+            if insight_lines:
+                lines.extend(["", "=== PLAYER CONTEXT (current form / streak / trend) ==="] + insight_lines)
     elif channel_key == "clan-events":
         has_likely_kick = any(s.get("likely_kicked") for s in (signals or []))
         if has_likely_kick:
@@ -530,6 +558,220 @@ async def _deliver_signal_group(signals, clan, war):
         await _mark_signal_group_completed(signals)
         return True
     return all(results)
+
+
+# ---------------------------------------------------------------------------
+# Awareness-loop delivery (Phase 4)
+# ---------------------------------------------------------------------------
+
+async def _deliver_awareness_post(post: dict, signals: list[dict]) -> bool:
+    """Deliver one post from an awareness post-plan to its target channel.
+
+    Reuses the existing Discord write path (`_post_to_elixir`) and message
+    log so downstream consumers (memory extraction, recap storage) keep
+    working unchanged.
+    """
+    from runtime.situation import CHANNEL_LANES
+    channel_key = (post.get("channel") or "").strip()
+    if channel_key not in CHANNEL_LANES:
+        log.warning("awareness post rejected: unknown channel %r", channel_key)
+        return False
+    leads_with = (post.get("leads_with") or "").strip()
+    if leads_with and leads_with not in CHANNEL_LANES[channel_key]:
+        log.warning(
+            "awareness post rejected: leads_with=%r not allowed on channel=%r (allowed=%s)",
+            leads_with, channel_key, sorted(CHANNEL_LANES[channel_key]),
+        )
+        return False
+
+    try:
+        channel_config = _channel_config_by_key(channel_key)
+    except RuntimeError:
+        log.warning("awareness post rejected: channel %r not configured", channel_key)
+        return False
+    channel = bot.get_channel(channel_config["id"])
+    if not channel:
+        log.warning("awareness post rejected: channel %r not found in Discord", channel_key)
+        return False
+
+    content = post.get("content")
+    if not content:
+        log.warning("awareness post on %r had empty content", channel_key)
+        return False
+
+    result = {
+        "event_type": post.get("event_type") or "awareness_update",
+        "summary": post.get("summary"),
+        "content": content,
+    }
+    try:
+        await _post_to_elixir(channel, result)
+    except Exception:
+        log.error("awareness post send failed channel=%r", channel_key, exc_info=True)
+        return False
+
+    posts = _app._entry_posts(result)
+    channel_id = channel_config["id"]
+    channel_name = getattr(channel, "name", None)
+    if not isinstance(channel_name, str):
+        channel_name = None
+    channel_kind = getattr(channel, "type", None)
+    if channel_kind is not None:
+        channel_kind = str(channel_kind)
+    summary = result.get("summary")
+    event_type = result.get("event_type")
+    for index, body_part in enumerate(posts):
+        post_summary = summary if index == 0 else f"{summary} ({index + 1}/{len(posts)})" if summary else None
+        post_event_type = event_type if index == 0 else f"{event_type}_part"
+        await asyncio.to_thread(
+            db.save_message,
+            _channel_scope(channel),
+            "assistant",
+            body_part,
+            summary=post_summary,
+            channel_id=channel_id,
+            channel_name=channel_name,
+            channel_kind=channel_kind,
+            workflow=channel_config["subagent_key"],
+            event_type=post_event_type,
+            raw_json={
+                "source": "awareness_loop",
+                "leads_with": post.get("leads_with"),
+                "covers_signal_keys": post.get("covers_signal_keys") or [],
+                "result": result,
+            },
+        )
+
+    # Persist signal outcomes so the existing dedupe/stats path stays intact.
+    body = "\n\n".join(posts)
+    covers = list(post.get("covers_signal_keys") or [])
+    for signal in signals or []:
+        sig_key = signal.get("signal_key") or signal.get("signal_log_type")
+        if not sig_key or sig_key not in covers:
+            continue
+        await asyncio.to_thread(
+            db.upsert_signal_outcome,
+            sig_key,
+            signal.get("type") or "awareness_signal",
+            channel_key,
+            channel_id,
+            event_type,
+            required=True,
+            delivery_status="delivered",
+            payload={"result": result, "signals": [signal]},
+            mark_attempt=True,
+            delivered=True,
+        )
+
+    # Memory extraction — same fire-and-forget pattern as per-signal delivery.
+    from runtime.helpers._common import _safe_create_task
+    fake_outcome = {
+        "intent": event_type,
+        "target_channel_key": channel_key,
+        "target_channel_id": channel_id,
+        "source_signal_key": (covers[0] if covers else "awareness_loop"),
+    }
+    _safe_create_task(
+        _post_signal_memory(body, fake_outcome, signals or []),
+        name="awareness_signal_memory",
+    )
+    return True
+
+
+async def _deliver_awareness_post_plan(plan: dict, signals: list[dict]) -> dict:
+    """Deliver every valid post in an awareness post plan.
+
+    Returns a report dict: ``{"delivered": int, "rejected": int,
+    "covered_signal_keys": set[str]}``. The caller compares
+    ``covered_signal_keys`` against ``hard_post_signals`` and falls back to
+    the legacy per-signal delivery path for any uncovered hard-post-floor
+    signals.
+    """
+    posts = (plan or {}).get("posts") or []
+    delivered = 0
+    rejected = 0
+    covered: set[str] = set()
+    for post in posts:
+        ok = await _deliver_awareness_post(post, signals or [])
+        if ok:
+            delivered += 1
+            for key in post.get("covers_signal_keys") or []:
+                if key:
+                    covered.add(str(key))
+        else:
+            rejected += 1
+    return {
+        "delivered": delivered,
+        "rejected": rejected,
+        "covered_signal_keys": covered,
+    }
+
+
+async def _deliver_signal_group_via_awareness(signals, clan, war) -> bool:
+    """Awareness-loop replacement for ``_deliver_signal_group``.
+
+    1. Build the situation from ``signals + clan + war``.
+    2. Fast-path: if quiet (no signals, no hard floors, not near deadline),
+       return True without calling the LLM.
+    3. Run the awareness agent.
+    4. Validate + deliver the post plan.
+    5. For any hard-post-floor signal not covered by the plan, fall back to
+       the legacy per-signal ``_deliver_signal_group`` for *just that signal*
+       so coverage is guaranteed.
+
+    Returns True iff every required signal was delivered through some path.
+    """
+    from runtime.situation import build_situation, situation_is_quiet
+    from heartbeat import HeartbeatTickResult
+
+    bundle = HeartbeatTickResult(signals=signals or [], clan=clan or {}, war=war or {})
+    situation = build_situation(bundle)
+
+    if situation_is_quiet(situation):
+        log.info("awareness loop: quiet tick, skipping agent call")
+        return True
+
+    try:
+        plan = await asyncio.to_thread(elixir_agent.run_awareness_tick, situation)
+    except Exception as exc:
+        log.error("awareness loop run_awareness_tick failed: %s", exc, exc_info=True)
+        plan = None
+
+    if plan is None:
+        log.warning("awareness loop returned no plan; falling back to per-signal delivery")
+        return await _deliver_signal_group(signals, clan, war)
+
+    report = await _deliver_awareness_post_plan(plan, signals)
+    log.info(
+        "awareness loop: delivered=%d rejected=%d covered_keys=%d",
+        report["delivered"], report["rejected"], len(report["covered_signal_keys"]),
+    )
+
+    # Hard-post-floor fallback: any required signal the agent omitted must
+    # still produce a post via the legacy per-signal path.
+    hard_required = situation.get("hard_post_signals") or []
+    uncovered = [
+        signal
+        for signal in (signals or [])
+        if any(
+            (signal.get("signal_key") or signal.get("signal_log_type")) == hp.get("signal_key")
+            for hp in hard_required
+        )
+        and (signal.get("signal_key") or signal.get("signal_log_type")) not in report["covered_signal_keys"]
+    ]
+    if uncovered:
+        log.warning(
+            "awareness loop: %d hard-post-floor signal(s) uncovered; falling back per-signal",
+            len(uncovered),
+        )
+        all_ok = True
+        for signal in uncovered:
+            ok = await _deliver_signal_group([signal], clan, war)
+            all_ok = all_ok and ok
+        if not all_ok:
+            return False
+
+    return True
 
 
 def _strip_weekly_recap_header(text: str) -> str:

--- a/runtime/situation.py
+++ b/runtime/situation.py
@@ -1,0 +1,249 @@
+"""Awareness-loop situation assembler.
+
+Builds the single ``Situation`` payload handed to the awareness agent each
+heartbeat tick. The situation collapses what used to be N per-signal context
+envelopes into one end-to-end picture: time/phase, standing, all signals
+since the last tick grouped by lane, recent channel posts (memory), roster
+vitals, and an explicit list of hard-post-floor signals.
+
+The assembler is pure: it takes a heartbeat tick result + clan/war and
+queries the local DB for memory and form data. It does no Discord I/O and
+no LLM calls — that's the agent's job.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+import db
+import prompts
+from heartbeat import build_situation_time
+from runtime.channel_subagents import (
+    BATTLE_MODE_SIGNAL_TYPES,
+    CLAN_EVENT_SIGNAL_TYPES,
+    LEADERSHIP_ONLY_SIGNAL_TYPES,
+    PROGRESSION_SIGNAL_TYPES,
+    is_war_signal,
+    signal_audience,
+    signal_source_key,
+)
+
+log = logging.getLogger("elixir")
+
+
+# Signals that the awareness loop is REQUIRED to address. The agent picks
+# tone, channel (within lane rules), and phrasing; existence is non-negotiable.
+HARD_POST_SIGNAL_TYPES = frozenset({
+    "war_battle_rank_change",
+    "war_week_complete",
+    "war_season_complete",
+    "war_completed",
+    "member_join",
+    "member_leave",
+    "capability_unlock",
+})
+
+
+# Channel allowlist used by post-plan validation. Each channel's lane keys
+# describe the signal-family hints (`leads_with`) that may legitimately ship
+# there.
+CHANNEL_LANES: dict[str, set[str]] = {
+    "river-race": {"war"},
+    "trophy-road": {"battle_mode"},
+    "player-progress": {"milestone"},
+    "clan-events": {"clan_event"},
+    "leader-lounge": {"war", "leadership", "clan_event"},
+    "announcements": {"system"},
+}
+
+
+def classify_signal_lane(signal: dict) -> str:
+    """Return the lane key for a signal: war / battle_mode / milestone /
+    clan_event / leadership / system / unknown."""
+    sig_type = (signal or {}).get("type") or ""
+    if is_war_signal(signal):
+        return "war"
+    if sig_type in BATTLE_MODE_SIGNAL_TYPES:
+        return "battle_mode"
+    if sig_type in PROGRESSION_SIGNAL_TYPES:
+        return "milestone"
+    if sig_type in CLAN_EVENT_SIGNAL_TYPES:
+        return "clan_event"
+    if sig_type in LEADERSHIP_ONLY_SIGNAL_TYPES or signal_audience(signal) == "leadership":
+        return "leadership"
+    if sig_type == "capability_unlock":
+        return "system"
+    return "unknown"
+
+
+def _annotate_signal(signal: dict) -> dict:
+    """Attach a stable signal_key + lane to each signal so the agent has a
+    deterministic identifier to echo back in `covers_signal_keys`."""
+    annotated = dict(signal or {})
+    if not annotated.get("signal_key"):
+        annotated["signal_key"] = signal_source_key(signal)
+    annotated["_lane"] = classify_signal_lane(signal)
+    return annotated
+
+
+def _group_signals_by_lane(signals: Iterable[dict]) -> dict[str, list[dict]]:
+    grouped: dict[str, list[dict]] = {}
+    for signal in signals or []:
+        annotated = _annotate_signal(signal)
+        grouped.setdefault(annotated["_lane"], []).append(annotated)
+    return grouped
+
+
+def _hard_post_signals(signals: Iterable[dict]) -> list[dict]:
+    out = []
+    for signal in signals or []:
+        sig_type = signal.get("type") or ""
+        if sig_type in HARD_POST_SIGNAL_TYPES:
+            out.append({
+                "signal_key": signal_source_key(signal),
+                "type": sig_type,
+                "tag": signal.get("tag"),
+                "name": signal.get("name"),
+            })
+    return out
+
+
+def _build_standing(war: dict | None) -> dict | None:
+    """Compact standing summary — rank, fame, deficit-to-leader, engagement."""
+    war = war or {}
+    clans = war.get("clans") or []
+    clan_obj = war.get("clan") or {}
+    if not clan_obj.get("tag"):
+        return None
+    our_tag = clan_obj["tag"].strip("#").upper()
+    ranked = sorted(
+        clans,
+        key=lambda c: (c.get("fame") or 0, c.get("repairPoints") or 0),
+        reverse=True,
+    )
+    our_fame = None
+    our_rank = None
+    leader_fame = ranked[0].get("fame") if ranked else None
+    for rank, c in enumerate(ranked, start=1):
+        tag = (c.get("tag") or "").strip("#").upper()
+        if tag == our_tag:
+            our_fame = c.get("fame") or 0
+            our_rank = rank
+            break
+    if our_fame is None:
+        return None
+    return {
+        "rank": our_rank,
+        "fame": our_fame,
+        "leader_fame": leader_fame,
+        "deficit_to_leader": (leader_fame - our_fame) if (leader_fame is not None and our_rank != 1) else 0,
+        "field_size": len(ranked),
+    }
+
+
+def _channel_memory_for(subagent_key: str, *, recent_limit: int = 5) -> dict:
+    """Pull recent assistant posts for one channel so the agent knows what it
+    has already said. Pure DB read, no Discord call."""
+    try:
+        config = prompts.discord_singleton_subagent(subagent_key)
+    except (ValueError, KeyError):
+        return {"recent_posts": []}
+    try:
+        recent = db.list_channel_messages(config["id"], recent_limit, "assistant") or []
+    except Exception:
+        log.warning("channel_memory load failed for %s", subagent_key, exc_info=True)
+        recent = []
+    return {
+        "channel_id": config["id"],
+        "recent_posts": [
+            {
+                "summary": row.get("summary"),
+                "recorded_at": row.get("recorded_at"),
+                "event_type": row.get("event_type"),
+            }
+            for row in recent
+        ],
+    }
+
+
+def _roster_vitals(limit: int = 20) -> list[dict]:
+    """Compact roster anchor: hot-streak members + clan summary snippet.
+
+    Read-only scouting input. Not for verbatim posting — the agent uses it to
+    decide whether anyone is doing something noteworthy this tick.
+    """
+    out: list[dict] = []
+    try:
+        hot = db.get_members_on_hot_streak() or []
+        for entry in hot[:limit]:
+            out.append({
+                "kind": "hot_streak",
+                "tag": entry.get("tag"),
+                "name": entry.get("name") or entry.get("current_name"),
+                "streak": entry.get("current_streak"),
+            })
+    except Exception:
+        log.warning("roster_vitals: hot streak load failed", exc_info=True)
+    return out
+
+
+def build_situation(tick_result, *, channel_keys: Iterable[str] | None = None) -> dict:
+    """Assemble the single Situation payload for one awareness tick.
+
+    ``tick_result`` is a ``HeartbeatTickResult`` (signals + clan + war).
+    Returns a dict whose top-level keys are stable for the agent's prompt:
+    ``time``, ``standing``, ``signals_by_lane``, ``hard_post_signals``,
+    ``channel_memory``, ``roster_vitals``.
+    """
+    signals = list(getattr(tick_result, "signals", None) or [])
+    clan = getattr(tick_result, "clan", None) or {}
+    war = getattr(tick_result, "war", None) or {}
+
+    if channel_keys is None:
+        channel_keys = list(CHANNEL_LANES.keys())
+
+    return {
+        "time": build_situation_time(),
+        "standing": _build_standing(war),
+        "signals_by_lane": _group_signals_by_lane(signals),
+        "hard_post_signals": _hard_post_signals(signals),
+        "channel_memory": {
+            key: _channel_memory_for(key) for key in channel_keys
+        },
+        "roster_vitals": _roster_vitals(),
+        "_raw_signal_count": len(signals),
+        "_clan_tag": (clan.get("tag") or "").strip(),
+    }
+
+
+def situation_is_quiet(situation: dict) -> bool:
+    """Fast-path: should the awareness agent call be skipped entirely?
+
+    Quiet means: no signals at all, no hard-post floors, and no time-boundary
+    pressure (>1h from any battle-day deadline). Mirrors the existing
+    ``_clan_awareness_tick`` early-return so quiet ticks keep costing nothing.
+    """
+    if situation.get("_raw_signal_count"):
+        return False
+    if situation.get("hard_post_signals"):
+        return False
+    time_block = situation.get("time") or {}
+    hours_remaining = time_block.get("hours_remaining_in_day")
+    # Within an hour of a battle-day deadline → not quiet, agent should look.
+    if (
+        time_block.get("phase") == "battle"
+        and hours_remaining is not None
+        and hours_remaining <= 1
+    ):
+        return False
+    return True
+
+
+__all__ = [
+    "CHANNEL_LANES",
+    "HARD_POST_SIGNAL_TYPES",
+    "build_situation",
+    "classify_signal_lane",
+    "situation_is_quiet",
+]

--- a/runtime/system_signals.py
+++ b/runtime/system_signals.py
@@ -572,6 +572,41 @@ STARTUP_SYSTEM_SIGNALS = [
             "capability_area": "omnipresent",
         },
     },
+    {
+        "signal_key": "capability_coherent_v1",
+        "signal_type": "capability_unlock",
+        "payload": {
+            "title": "Achievement Unlocked: Coherent",
+            "message": (
+                "Elixir's proactive posting flipped from one LLM call per signal to one agent turn per heartbeat. "
+                "I now see the full situation each tick — what's happened, where in the war week we are, what each channel has heard from me — and I decide what (if anything) is worth saying."
+            ),
+            "discord_content": (
+                "**Achievement Unlocked: Coherent** :elixir:\n\n"
+                "I used to react to one signal at a time. Now I see the whole tick at once and decide what's worth saying.\n\n"
+                "**What's different:**\n"
+                "- **I investigate before I post.** When someone is on a streak, I pull their recent battles to see who they were beating before I write the callout. The post leads with what was actually faced, not just the streak count.\n"
+                "- **I collapse related signals.** When a battle day ends, the week rolls over, and the next practice phase starts in the same tick, that's now one post that recaps and pivots — not five posts racing each other into the channel.\n"
+                "- **I'm allowed to be silent.** When the data has already gone stale (a hot-streak signal whose live battle log shows the streak broke), I skip and log why. Silence is a real choice now.\n"
+                "- **I always know what time it is.** Hours-remaining, day index, war phase, and colosseum status attach to every post — no waiting for a checkpoint to fire to talk about the clock.\n\n"
+                "**New channel: #trophy-road**\n"
+                "- Volatile non-war battle activity moves here: hot streaks, trophy pushes, Path of Legends promotions, and future Challenge / Tournament finishes.\n"
+                "- **#player-progress** narrows to durable milestones — arena unlocks, level-ups, card unlocks, badges, achievements. The mixing problem is gone.\n\n"
+                "This is **Elixir v4.5 \"Coherent\"** — one mind per tick, watching the whole situation, deciding what's worth your attention."
+            ),
+            "details": [
+                "New per-tick awareness loop replaces per-signal LLM calls — one agent turn sees all signals together and emits a structured post plan.",
+                "Agent investigates before posting via cr_api (streak opponents, rival clans) so posts cite specific evidence instead of restating signal dicts.",
+                "Coherent timing: related signals (war cascade, mixed milestone+roster batches) collapse into one sequenced post per channel instead of N independent posts.",
+                "Genuine silence is allowed — stale signals get caught and skipped with a logged reason; quiet ticks fast-path skip the LLM call entirely.",
+                "Hard-post-floor fallback guarantees coverage for member_join, war_battle_rank_change, capability_unlock, and week/season completion signals.",
+                "New #trophy-road channel for volatile battle-mode activity; #player-progress narrowed to durable milestones.",
+                "Time/phase/standing context now attaches to every channel post, not just war checkpoints.",
+            ],
+            "audience": "clan",
+            "capability_area": "coherent",
+        },
+    },
 ]
 
 

--- a/scripts/replay_awareness.py
+++ b/scripts/replay_awareness.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Awareness-loop replay harness.
+
+Pulls real signal payloads from the local elixir.db, constructs a series of
+realistic "tick" scenarios, and runs each one through ``run_awareness_tick``
+WITHOUT touching Discord. Dumps a structured report of every situation +
+post plan to ``scripts/replay_awareness_report.md`` for human review.
+
+This is a one-off integration test for Phase 4 of the awareness loop. It
+exercises the real LLM (uses the ``ANTHROPIC_API_KEY`` from .env) so post
+plans reflect what production would actually emit.
+
+Usage:
+    python scripts/replay_awareness.py [scenario_name ...]
+
+If no scenario names are given, every scenario runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import textwrap
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import elixir  # noqa: E402,F401  Seeds the runtime.app + jobs module graph.
+import heartbeat  # noqa: E402
+from agent.workflows import run_awareness_tick  # noqa: E402
+from runtime.situation import (  # noqa: E402
+    CHANNEL_LANES,
+    HARD_POST_SIGNAL_TYPES,
+    build_situation,
+    classify_signal_lane,
+    situation_is_quiet,
+)
+
+
+REPORT_PATH = REPO_ROOT / "scripts" / "replay_awareness_report.md"
+DB_PATH = REPO_ROOT / "elixir.db"
+
+
+# ---------------------------------------------------------------------------
+# Signal extraction from the live db
+# ---------------------------------------------------------------------------
+
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(DB_PATH))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _payload_signals(row) -> list[dict]:
+    payload = json.loads(row["payload_json"] or "{}")
+    return payload.get("signals") or []
+
+
+def latest_signals_of_type(conn, signal_type: str, limit: int = 1) -> list[dict]:
+    """Return the most recent N raw signals of one type from signal_outcomes."""
+    out: list[dict] = []
+    seen_keys: set[str] = set()
+    for row in conn.execute(
+        """
+        SELECT source_signal_key, payload_json
+        FROM signal_outcomes
+        WHERE source_signal_type = ?
+        ORDER BY created_at DESC
+        LIMIT ?
+        """,
+        (signal_type, limit * 4),
+    ):
+        if row["source_signal_key"] in seen_keys:
+            continue
+        seen_keys.add(row["source_signal_key"])
+        for sig in _payload_signals(row):
+            if sig.get("type") == signal_type:
+                out.append(sig)
+                break
+        if len(out) >= limit:
+            break
+    return out
+
+
+def latest_war_signal(conn, signal_type: str) -> dict | None:
+    sigs = latest_signals_of_type(conn, signal_type, limit=1)
+    return sigs[0] if sigs else None
+
+
+def latest_member_signal(conn, signal_type: str, limit: int = 2) -> list[dict]:
+    return latest_signals_of_type(conn, signal_type, limit=limit)
+
+
+# ---------------------------------------------------------------------------
+# Live clan / war state pulls (read-only, no LLM)
+# ---------------------------------------------------------------------------
+
+def load_live_war_payload(conn) -> dict:
+    """Return the most recent war_current_state raw_json so the situation
+    assembler has real standings/clan data to work with."""
+    row = conn.execute(
+        "SELECT raw_json FROM war_current_state ORDER BY war_id DESC LIMIT 1"
+    ).fetchone()
+    if not row:
+        return {}
+    try:
+        return json.loads(row["raw_json"]) or {}
+    except (TypeError, json.JSONDecodeError):
+        return {}
+
+
+def load_clan_metadata(conn) -> dict:
+    war = load_live_war_payload(conn)
+    return war.get("clan") or {}
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Scenario:
+    name: str
+    description: str
+    signal_builder: Any  # callable(conn) -> list[dict]
+
+
+def scenario_quiet_tick(conn) -> list[dict]:
+    return []
+
+
+def scenario_single_hot_streak(conn) -> list[dict]:
+    return latest_signals_of_type(conn, "battle_hot_streak", limit=1)
+
+
+def scenario_battle_day_complete(conn) -> list[dict]:
+    sig = latest_war_signal(conn, "war_battle_day_complete")
+    return [sig] if sig else []
+
+
+def scenario_member_join_pair(conn) -> list[dict]:
+    return latest_member_signal(conn, "member_join", limit=2)
+
+
+def scenario_card_unlock(conn) -> list[dict]:
+    return latest_signals_of_type(conn, "new_card_unlocked", limit=1)
+
+
+def scenario_arena_change(conn) -> list[dict]:
+    return latest_signals_of_type(conn, "arena_change", limit=1)
+
+
+def scenario_path_of_legend(conn) -> list[dict]:
+    return latest_signals_of_type(conn, "path_of_legend_promotion", limit=1)
+
+
+def scenario_busy_mixed_tick(conn) -> list[dict]:
+    """The realistic case the awareness loop is designed for: war + battle
+    mode + milestone + roster all hit in the same tick."""
+    out: list[dict] = []
+    for sig_type in (
+        "war_battle_day_complete",
+        "battle_hot_streak",
+        "new_card_unlocked",
+        "member_join",
+    ):
+        sigs = latest_signals_of_type(conn, sig_type, limit=1)
+        out.extend(sigs)
+    return out
+
+
+def scenario_war_completion_cascade(conn) -> list[dict]:
+    """The actual 2026-04-13T10 cascade: practice phase + battle days complete
+    + week rollover + war completed all in one cycle."""
+    out: list[dict] = []
+    for sig_type in (
+        "war_battle_day_complete",
+        "war_battle_days_complete",
+        "war_week_rollover",
+        "war_completed",
+        "war_practice_phase_active",
+    ):
+        sig = latest_war_signal(conn, sig_type)
+        if sig:
+            out.append(sig)
+    return out
+
+
+def scenario_capability_unlock(conn) -> list[dict]:
+    return latest_signals_of_type(conn, "capability_unlock", limit=1)
+
+
+SCENARIOS: list[Scenario] = [
+    Scenario(
+        "quiet_tick",
+        "No signals, mid-practice-day. Should produce zero posts (fast-path skip).",
+        scenario_quiet_tick,
+    ),
+    Scenario(
+        "single_hot_streak",
+        "One battle_hot_streak signal. Should produce one #trophy-road post that "
+        "ideally cites opponent evidence via cr_api lookup.",
+        scenario_single_hot_streak,
+    ),
+    Scenario(
+        "battle_day_complete",
+        "One war_battle_day_complete signal. Hard-floor; must produce a #river-race post.",
+        scenario_battle_day_complete,
+    ),
+    Scenario(
+        "member_join_pair",
+        "Two new members joined. Hard-floor for both. Should land on #clan-events "
+        "(public welcome) and #leader-lounge (ops note).",
+        scenario_member_join_pair,
+    ),
+    Scenario(
+        "card_unlock",
+        "Durable milestone. Should land on #player-progress (NOT #trophy-road).",
+        scenario_card_unlock,
+    ),
+    Scenario(
+        "arena_change",
+        "Durable milestone. Should land on #player-progress.",
+        scenario_arena_change,
+    ),
+    Scenario(
+        "path_of_legend",
+        "Volatile battle-mode signal (Phase 3 reroute). Should land on #trophy-road, "
+        "NOT #player-progress.",
+        scenario_path_of_legend,
+    ),
+    Scenario(
+        "busy_mixed_tick",
+        "War + battle-mode + milestone + roster all in one tick. Tests lane "
+        "discipline and coherent timing across multiple channels.",
+        scenario_busy_mixed_tick,
+    ),
+    Scenario(
+        "war_completion_cascade",
+        "End-of-week war cascade: battle day complete + week rollover + war complete + "
+        "next practice phase active. Should narratively sequence, not fire 4 separate posts.",
+        scenario_war_completion_cascade,
+    ),
+    Scenario(
+        "capability_unlock",
+        "System signal. Hard-floor; should land on #announcements.",
+        scenario_capability_unlock,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Plan validation (mirrors the real delivery layer's checks)
+# ---------------------------------------------------------------------------
+
+def validate_plan(plan: dict, situation: dict) -> dict:
+    """Return a validation report: lane mismatches, hard-floor coverage, etc."""
+    posts = (plan or {}).get("posts") or []
+    issues: list[str] = []
+    covered: set[str] = set()
+    for i, post in enumerate(posts):
+        channel = (post.get("channel") or "").strip()
+        leads_with = (post.get("leads_with") or "").strip()
+        if channel not in CHANNEL_LANES:
+            issues.append(f"post[{i}]: unknown channel {channel!r}")
+            continue
+        if leads_with and leads_with not in CHANNEL_LANES[channel]:
+            issues.append(
+                f"post[{i}]: leads_with={leads_with!r} not allowed on #{channel} "
+                f"(allowed: {sorted(CHANNEL_LANES[channel])})"
+            )
+        if not post.get("content"):
+            issues.append(f"post[{i}]: empty content")
+        for key in post.get("covers_signal_keys") or []:
+            if key:
+                covered.add(str(key))
+
+    hard_required = situation.get("hard_post_signals") or []
+    uncovered = [hp for hp in hard_required if hp.get("signal_key") not in covered]
+    return {
+        "post_count": len(posts),
+        "issues": issues,
+        "hard_floor_total": len(hard_required),
+        "hard_floor_covered": len(hard_required) - len(uncovered),
+        "hard_floor_uncovered": uncovered,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Patching: keep DB reads real but block any accidental Discord/network calls
+# ---------------------------------------------------------------------------
+
+class _NoDiscord:
+    """Block any unexpected Discord posts. The harness must not send."""
+
+    def __getattr__(self, name):
+        def _noop(*a, **kw):
+            raise RuntimeError(f"Discord call blocked in replay harness: {name}")
+        return _noop
+
+
+# ---------------------------------------------------------------------------
+# Run one scenario end-to-end
+# ---------------------------------------------------------------------------
+
+def run_scenario(scenario: Scenario, conn) -> dict:
+    signals = scenario.signal_builder(conn) or []
+    war = load_live_war_payload(conn)
+    clan = load_clan_metadata(conn)
+
+    bundle = heartbeat.HeartbeatTickResult(signals=signals, clan=clan, war=war)
+    situation = build_situation(bundle)
+    is_quiet = situation_is_quiet(situation)
+
+    if is_quiet:
+        return {
+            "scenario": scenario,
+            "signals": signals,
+            "situation": situation,
+            "is_quiet": True,
+            "plan": {"posts": [], "skipped_reason": "fast-path: situation is quiet"},
+            "validation": {
+                "post_count": 0,
+                "issues": [],
+                "hard_floor_total": 0,
+                "hard_floor_covered": 0,
+                "hard_floor_uncovered": [],
+            },
+            "error": None,
+        }
+
+    # Real LLM call. No Discord patches needed because run_awareness_tick
+    # itself never touches Discord — it only returns a post plan.
+    error = None
+    plan: dict | None = None
+    try:
+        plan = run_awareness_tick(situation)
+    except Exception as exc:
+        error = repr(exc)
+
+    if plan is None:
+        plan = {"posts": [], "skipped_reason": "agent returned None"}
+
+    return {
+        "scenario": scenario,
+        "signals": signals,
+        "situation": situation,
+        "is_quiet": False,
+        "plan": plan,
+        "validation": validate_plan(plan, situation),
+        "error": error,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def _short(value: Any, width: int = 80) -> str:
+    text = str(value)
+    return text if len(text) <= width else text[: width - 1] + "…"
+
+
+def render_report(results: list[dict]) -> str:
+    lines: list[str] = []
+    lines.append(f"# Awareness loop replay report — {datetime.now().isoformat(timespec='seconds')}\n")
+    total = len(results)
+    quiet = sum(1 for r in results if r["is_quiet"])
+    errors = sum(1 for r in results if r["error"])
+    issues = sum(len(r["validation"]["issues"]) for r in results)
+    floor_gap = sum(len(r["validation"]["hard_floor_uncovered"]) for r in results)
+    lines.append(
+        f"**Summary:** {total} scenarios · {quiet} quiet (skipped) · {errors} errors · "
+        f"{issues} validation issues · {floor_gap} uncovered hard-post floors\n"
+    )
+
+    for r in results:
+        s = r["scenario"]
+        lines.append(f"\n---\n\n## `{s.name}`\n")
+        lines.append(f"_{s.description}_\n")
+        lines.append("### Input signals\n")
+        if not r["signals"]:
+            lines.append("(none)\n")
+        else:
+            for sig in r["signals"]:
+                lines.append(
+                    f"- **{sig.get('type')}** "
+                    f"tag={sig.get('tag', '—')} "
+                    f"name={sig.get('name', '—')} "
+                    f"lane=`{classify_signal_lane(sig)}`"
+                )
+            lines.append("")
+
+        sit = r["situation"]
+        time_block = sit.get("time") or {}
+        standing = sit.get("standing") or {}
+        lines.append("### Situation snapshot\n")
+        lines.append(f"- time: phase={time_block.get('phase')} day={time_block.get('day_number')}/{time_block.get('day_total')} hrs_left={time_block.get('hours_remaining_in_day')} colosseum={time_block.get('is_colosseum_week')}")
+        lines.append(f"- standing: rank={standing.get('rank')} fame={standing.get('fame')} deficit={standing.get('deficit_to_leader')}")
+        lines.append(f"- hard_post_signals: {len(sit.get('hard_post_signals') or [])}")
+        lines.append(f"- roster_vitals: {len(sit.get('roster_vitals') or [])} entries\n")
+
+        if r["is_quiet"]:
+            lines.append("**Result:** quiet tick → fast-path skip (no LLM call). ✅\n")
+            continue
+
+        if r["error"]:
+            lines.append(f"**ERROR:** `{r['error']}`\n")
+            continue
+
+        v = r["validation"]
+        lines.append("### Validation\n")
+        lines.append(f"- posts: {v['post_count']}")
+        lines.append(f"- hard-floor coverage: {v['hard_floor_covered']}/{v['hard_floor_total']}")
+        if v["hard_floor_uncovered"]:
+            lines.append(f"- ⚠️  uncovered: {[hp.get('type') for hp in v['hard_floor_uncovered']]}")
+        if v["issues"]:
+            for issue in v["issues"]:
+                lines.append(f"- ⚠️  {issue}")
+        if not v["issues"] and not v["hard_floor_uncovered"]:
+            lines.append("- ✅ all checks pass")
+        lines.append("")
+
+        plan = r["plan"]
+        posts = plan.get("posts") or []
+        lines.append("### Post plan\n")
+        if plan.get("skipped_reason"):
+            lines.append(f"_skipped_reason:_ {plan['skipped_reason']}\n")
+        if not posts:
+            lines.append("_(no posts emitted)_\n")
+        for i, post in enumerate(posts):
+            lines.append(f"#### Post {i+1} → `#{post.get('channel')}`")
+            lines.append(f"- leads_with: `{post.get('leads_with')}` · tone: `{post.get('tone')}`")
+            lines.append(f"- summary: {post.get('summary') or '—'}")
+            lines.append(f"- covers_signal_keys: {post.get('covers_signal_keys') or []}")
+            content = post.get("content")
+            if isinstance(content, list):
+                for j, part in enumerate(content):
+                    lines.append(f"\n**Body part {j+1}:**\n\n{textwrap.indent(str(part), '> ')}\n")
+            else:
+                lines.append(f"\n**Body:**\n\n{textwrap.indent(str(content or ''), '> ')}\n")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("scenarios", nargs="*", help="optional list of scenario names to run")
+    parser.add_argument("--report", default=str(REPORT_PATH), help="path to write markdown report")
+    args = parser.parse_args()
+
+    if not os.environ.get("ANTHROPIC_API_KEY") and not os.environ.get("CLAUDE_API_KEY"):
+        # Try loading from .env
+        env_path = REPO_ROOT / ".env"
+        if env_path.exists():
+            for line in env_path.read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, val = line.partition("=")
+                if key.strip() and val.strip():
+                    os.environ.setdefault(key.strip(), val.strip())
+    # Anthropic SDK looks for ANTHROPIC_API_KEY; copy from CLAUDE_API_KEY if needed.
+    if not os.environ.get("ANTHROPIC_API_KEY") and os.environ.get("CLAUDE_API_KEY"):
+        os.environ["ANTHROPIC_API_KEY"] = os.environ["CLAUDE_API_KEY"]
+
+    conn = _connect()
+    selected = SCENARIOS
+    if args.scenarios:
+        selected = [s for s in SCENARIOS if s.name in args.scenarios]
+        unknown = set(args.scenarios) - {s.name for s in SCENARIOS}
+        if unknown:
+            print(f"Unknown scenarios: {unknown}", file=sys.stderr)
+            return 2
+
+    print(f"Running {len(selected)} scenario(s)…")
+    results: list[dict] = []
+    for scenario in selected:
+        print(f"  · {scenario.name} … ", end="", flush=True)
+        result = run_scenario(scenario, conn)
+        results.append(result)
+        if result["is_quiet"]:
+            print("quiet (skipped)")
+        elif result["error"]:
+            print(f"ERROR: {result['error']}")
+        else:
+            v = result["validation"]
+            tag = "ok" if not v["issues"] and not v["hard_floor_uncovered"] else "issues"
+            print(f"posts={v['post_count']} {tag}")
+
+    report = render_report(results)
+    Path(args.report).write_text(report)
+    print(f"\nReport written → {args.report}")
+
+    # Exit non-zero if any uncovered hard floors or validation issues, so this
+    # can gate a CI loop or release decision.
+    bad = any(r["error"] or r["validation"]["issues"] or r["validation"]["hard_floor_uncovered"]
+              for r in results)
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Test-suite-wide fixtures.
+
+The Elixir runtime calls ``load_dotenv()`` on import (see ``runtime/app.py``)
+so any flags set in the developer's ``.env`` would otherwise leak into tests.
+This module forces the test environment to a deterministic baseline.
+"""
+
+import os
+
+import pytest
+
+
+# Env vars that gate runtime behavior and should default OFF in tests so
+# tests reflect the legacy/default code path. Individual tests can opt in
+# by patching the env back on.
+_LEAKED_ENV_FLAGS = (
+    "ELIXIR_AWARENESS_LOOP",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_leaked_env_flags(monkeypatch):
+    for name in _LEAKED_ENV_FLAGS:
+        monkeypatch.delenv(name, raising=False)

--- a/tests/test_awareness_loop.py
+++ b/tests/test_awareness_loop.py
@@ -1,0 +1,233 @@
+"""Tests for the Phase 4 awareness-loop architecture."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+# Import elixir first so the full runtime.app + runtime.jobs module graph
+# loads cleanly. Importing runtime.jobs._signals directly first creates a
+# partial-load circular import (runtime.app → runtime.jobs → _core → _signals).
+import elixir  # noqa: F401
+import heartbeat
+import runtime.jobs._signals as signals_module
+from runtime.situation import (
+    CHANNEL_LANES,
+    HARD_POST_SIGNAL_TYPES,
+    build_situation,
+    classify_signal_lane,
+    situation_is_quiet,
+)
+
+
+# ---------------------------------------------------------------------------
+# Lane classification
+# ---------------------------------------------------------------------------
+
+def test_classify_signal_lane_war():
+    assert classify_signal_lane({"type": "war_battle_rank_change"}) == "war"
+    assert classify_signal_lane({"type": "war_week_complete"}) == "war"
+
+
+def test_classify_signal_lane_battle_mode():
+    assert classify_signal_lane({"type": "battle_hot_streak"}) == "battle_mode"
+    assert classify_signal_lane({"type": "battle_trophy_push"}) == "battle_mode"
+    assert classify_signal_lane({"type": "path_of_legend_promotion"}) == "battle_mode"
+
+
+def test_classify_signal_lane_milestone():
+    assert classify_signal_lane({"type": "arena_change"}) == "milestone"
+    assert classify_signal_lane({"type": "new_card_unlocked"}) == "milestone"
+    # path_of_legend_promotion was moved to battle_mode in Phase 3 — should NOT
+    # land in milestone any more.
+    assert classify_signal_lane({"type": "path_of_legend_promotion"}) != "milestone"
+
+
+def test_classify_signal_lane_clan_event_and_system():
+    assert classify_signal_lane({"type": "member_join"}) == "clan_event"
+    assert classify_signal_lane({"type": "capability_unlock"}) == "system"
+
+
+def test_classify_signal_lane_leadership_audience():
+    assert classify_signal_lane({"type": "inactive_members"}) == "leadership"
+    assert classify_signal_lane({"type": "anything", "audience": "leadership"}) == "leadership"
+
+
+def test_classify_signal_lane_unknown_falls_through():
+    assert classify_signal_lane({"type": "thoroughly_unknown"}) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Situation assembler
+# ---------------------------------------------------------------------------
+
+def _bundle(signals=None, war=None, clan=None):
+    return heartbeat.HeartbeatTickResult(
+        signals=signals or [],
+        clan=clan or {},
+        war=war or {},
+    )
+
+
+def test_build_situation_groups_signals_by_lane():
+    bundle = _bundle(signals=[
+        {"type": "war_battle_rank_change", "signal_key": "war:rank:1"},
+        {"type": "battle_hot_streak", "tag": "#A", "signal_key": "streak:A"},
+        {"type": "arena_change", "tag": "#B", "signal_key": "arena:B"},
+        {"type": "member_join", "tag": "#C", "signal_key": "join:C"},
+    ])
+    with patch.object(signals_module.db, "list_channel_messages", return_value=[]), \
+         patch("runtime.situation.db.list_channel_messages", return_value=[]), \
+         patch("runtime.situation.build_situation_time", return_value={"phase": "battle"}):
+        situation = build_situation(bundle)
+
+    grouped = situation["signals_by_lane"]
+    assert {sig["type"] for sig in grouped["war"]} == {"war_battle_rank_change"}
+    assert {sig["type"] for sig in grouped["battle_mode"]} == {"battle_hot_streak"}
+    assert {sig["type"] for sig in grouped["milestone"]} == {"arena_change"}
+    assert {sig["type"] for sig in grouped["clan_event"]} == {"member_join"}
+
+
+def test_build_situation_lists_hard_post_signals():
+    bundle = _bundle(signals=[
+        {"type": "member_join", "signal_key": "join:1", "tag": "#A", "name": "Alice"},
+        {"type": "battle_hot_streak", "signal_key": "streak:1", "tag": "#A", "name": "Alice"},
+    ])
+    with patch("runtime.situation.db.list_channel_messages", return_value=[]), \
+         patch("runtime.situation.build_situation_time", return_value=None):
+        situation = build_situation(bundle)
+    types = [hp["type"] for hp in situation["hard_post_signals"]]
+    assert types == ["member_join"]
+    # battle_hot_streak is NOT a hard floor — agent may choose silence on it.
+    assert "battle_hot_streak" not in types
+
+
+def test_build_situation_includes_channel_memory_for_each_lane_channel():
+    bundle = _bundle(signals=[])
+    with patch("runtime.situation.db.list_channel_messages", return_value=[]), \
+         patch("runtime.situation.build_situation_time", return_value=None):
+        situation = build_situation(bundle)
+    assert set(situation["channel_memory"].keys()) >= set(CHANNEL_LANES.keys())
+
+
+# ---------------------------------------------------------------------------
+# Quiet-tick fast path
+# ---------------------------------------------------------------------------
+
+def test_situation_is_quiet_when_no_signals_and_no_clock_pressure():
+    situation = {
+        "_raw_signal_count": 0,
+        "hard_post_signals": [],
+        "time": {"phase": "practice", "hours_remaining_in_day": 18},
+    }
+    assert situation_is_quiet(situation) is True
+
+
+def test_situation_is_not_quiet_when_signals_present():
+    situation = {
+        "_raw_signal_count": 1,
+        "hard_post_signals": [],
+        "time": {"phase": "practice", "hours_remaining_in_day": 18},
+    }
+    assert situation_is_quiet(situation) is False
+
+
+def test_situation_is_not_quiet_with_hard_post_floor():
+    situation = {
+        "_raw_signal_count": 0,
+        "hard_post_signals": [{"signal_key": "join:1", "type": "member_join"}],
+        "time": None,
+    }
+    assert situation_is_quiet(situation) is False
+
+
+def test_situation_is_not_quiet_within_one_hour_of_battle_deadline():
+    situation = {
+        "_raw_signal_count": 0,
+        "hard_post_signals": [],
+        "time": {"phase": "battle", "hours_remaining_in_day": 1},
+    }
+    assert situation_is_quiet(situation) is False
+
+
+# ---------------------------------------------------------------------------
+# Post-plan delivery: lane validation + hard-post fallback
+# ---------------------------------------------------------------------------
+
+def test_deliver_awareness_post_rejects_unknown_channel():
+    post = {"channel": "ghost-channel", "leads_with": "war", "content": "x"}
+    delivered = asyncio.run(signals_module._deliver_awareness_post(post, []))
+    assert delivered is False
+
+
+def test_deliver_awareness_post_rejects_lane_mismatch():
+    # river-race lane only allows leads_with="war"
+    post = {"channel": "river-race", "leads_with": "milestone", "content": "x"}
+    delivered = asyncio.run(signals_module._deliver_awareness_post(post, []))
+    assert delivered is False
+
+
+def test_deliver_signal_group_via_awareness_falls_back_for_uncovered_hard_floor():
+    """When the agent omits a hard-post-floor signal, we fall back to the
+    legacy per-signal delivery path so coverage is guaranteed."""
+    member_join = {
+        "type": "member_join",
+        "signal_key": "join:abc",
+        "tag": "#ABC",
+        "name": "Alice",
+    }
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    # Agent emits an empty post plan — nothing covered.
+    empty_plan = {"posts": [], "skipped_reason": "agent felt quiet"}
+
+    with (
+        patch("runtime.jobs._signals.asyncio.to_thread", side_effect=fake_to_thread),
+        patch("runtime.situation.db.list_channel_messages", return_value=[]),
+        patch("runtime.situation.build_situation_time", return_value=None),
+        patch("runtime.situation.db.get_members_on_hot_streak", return_value=[]),
+        patch("runtime.jobs._signals.elixir_agent.run_awareness_tick", return_value=empty_plan),
+        patch(
+            "runtime.jobs._signals._deliver_signal_group",
+            new=AsyncMock(return_value=True),
+        ) as mock_legacy,
+    ):
+        ok = asyncio.run(
+            signals_module._deliver_signal_group_via_awareness([member_join], {}, {})
+        )
+
+    assert ok is True
+    # Legacy path was invoked with just the uncovered hard-floor signal.
+    mock_legacy.assert_awaited_once()
+    args, _ = mock_legacy.await_args
+    assert args[0] == [member_join]
+
+
+def test_deliver_signal_group_via_awareness_skips_quiet_tick():
+    """When situation is quiet, the agent is never called."""
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    with (
+        patch("runtime.jobs._signals.asyncio.to_thread", side_effect=fake_to_thread),
+        patch("runtime.situation.db.list_channel_messages", return_value=[]),
+        patch("runtime.situation.build_situation_time", return_value={"phase": "practice", "hours_remaining_in_day": 18}),
+        patch("runtime.situation.db.get_members_on_hot_streak", return_value=[]),
+        patch(
+            "runtime.jobs._signals.elixir_agent.run_awareness_tick",
+        ) as mock_agent,
+    ):
+        ok = asyncio.run(signals_module._deliver_signal_group_via_awareness([], {}, {}))
+
+    assert ok is True
+    mock_agent.assert_not_called()
+
+
+def test_hard_post_signal_types_includes_join_and_capability():
+    # Sanity: the floor set the agent contract relies on actually contains
+    # the signals the rest of the codebase considers "must-post."
+    assert "member_join" in HARD_POST_SIGNAL_TYPES
+    assert "member_leave" in HARD_POST_SIGNAL_TYPES
+    assert "capability_unlock" in HARD_POST_SIGNAL_TYPES
+    assert "war_battle_rank_change" in HARD_POST_SIGNAL_TYPES

--- a/tests/test_elixir_heartbeat.py
+++ b/tests/test_elixir_heartbeat.py
@@ -507,6 +507,69 @@ def test_plan_signal_outcomes_routes_leadership_audience_system_signal_to_leader
     assert outcomes[0]["target_channel_key"] == "leader-lounge"
 
 
+def test_plan_signal_outcomes_routes_battle_hot_streak_to_trophy_road():
+    outcomes = plan_signal_outcomes([{
+        "type": "battle_hot_streak",
+        "tag": "#ABC",
+        "name": "King Levy",
+        "streak": 8,
+    }])
+
+    assert len(outcomes) == 1
+    assert outcomes[0]["target_channel_key"] == "trophy-road"
+    assert outcomes[0]["intent"] == "battle_mode_update"
+    assert outcomes[0]["required"] is True
+
+
+def test_plan_signal_outcomes_routes_path_of_legend_promotion_to_trophy_road():
+    outcomes = plan_signal_outcomes([{
+        "type": "path_of_legend_promotion",
+        "tag": "#ABC",
+        "name": "King Levy",
+        "league": "Champion II",
+    }])
+
+    assert len(outcomes) == 1
+    assert outcomes[0]["target_channel_key"] == "trophy-road"
+
+
+def test_plan_signal_outcomes_routes_durable_milestone_to_player_progress():
+    outcomes = plan_signal_outcomes([{
+        "type": "new_card_unlocked",
+        "tag": "#ABC",
+        "name": "King Levy",
+        "card_name": "Mirror",
+        "rarity": "legendary",
+    }])
+
+    assert len(outcomes) == 1
+    assert outcomes[0]["target_channel_key"] == "player-progress"
+
+
+def test_plan_signal_outcomes_splits_mixed_durable_and_battle_mode_batch():
+    outcomes = plan_signal_outcomes([
+        {"type": "battle_hot_streak", "tag": "#ABC", "name": "King Levy", "streak": 6},
+        {"type": "arena_change", "tag": "#ABC", "name": "King Levy"},
+    ])
+
+    channels = [o["target_channel_key"] for o in outcomes]
+    assert "trophy-road" in channels
+    assert "player-progress" in channels
+
+
+def test_battle_mode_group_classifies_known_modes():
+    from storage.player import _battle_mode_group
+
+    assert _battle_mode_group(is_war=1) == "war"
+    assert _battle_mode_group(is_ranked=1) == "ranked"
+    assert _battle_mode_group(is_ladder=1) == "ladder"
+    assert _battle_mode_group(is_special_event=1) == "special_event"
+    assert _battle_mode_group(is_hosted_match=True) == "friendly"
+    assert _battle_mode_group() == "other"
+    # War wins the priority race over other flags
+    assert _battle_mode_group(is_war=1, is_ladder=1, is_ranked=1) == "war"
+
+
 def test_plan_signal_outcomes_makes_badge_level_only_batches_optional():
     outcomes = plan_signal_outcomes([{
         "type": "badge_level_milestone",


### PR DESCRIPTION
## Summary

- **Phase 1–4 of the unified awareness loop** ([vision doc](docs/tasks/agentic-awareness-loop.md)). Replaces N per-signal LLM calls with one agent turn per heartbeat that sees the full situation and decides what to post where.
- **New `#trophy-road` channel** (id `1493787763538133204`) for volatile non-war battle activity. `#player-progress` narrowed to durable milestones — the mixing problem is gone.
- **Time/phase/standing awareness attaches to every post**, not just war checkpoints.
- **`channel_update` workflow gets `cr_api` + 6 tool rounds** so per-signal posts can investigate too (used as the hard-post-floor fallback path).

## What's qualitatively different

Replay harness (`scripts/replay_awareness.py`) ran 10 real-data scenarios through the new loop three times. Highlights from real production-data replay:

- **Stale-signal silence:** `battle_hot_streak` for gooba — agent called `cr_api(player_battles)`, found the streak had ended with 3 consecutive losses, chose silence with a logged reason. Per-signal flow would have shipped a wrong post.
- **Coherent timing:** end-of-week war cascade (5 signals: battle day complete + week rollover + war complete + practice phase active) — agent emits one sequenced #river-race post (recap → tactical pivot to next phase) instead of 5 separate posts racing into the channel.
- **Investigative posts:** new-member welcome posts cite the player's deck, trophy count, and battles-played count via `cr_api(player)` lookups.

## Cutover

- Gated by `ELIXIR_AWARENESS_LOOP=true` env flag — already set in production. Legacy per-signal router stays available; flag will be removed after one clean war week.
- Hard-post-floor signals (member_join, member_leave, war_battle_rank_change, capability_unlock, war_week_complete, war_season_complete) are guaranteed to ship: if the agent omits one, the legacy per-signal path delivers it.

## Release artifacts (per `/new-release`)

- `agent/core.py` — `RELEASE_VERSION` v4.4 → v4.5, `RELEASE_CODENAME` Omnipresent → Coherent.
- `RELEASES.md` — new "v4.5 — Coherent" section.
- `runtime/system_signals.py` — `capability_coherent_v1` system signal queued for #announcements (1438 chars, Discord-clean).

## Test plan

- [x] `pytest tests/ -q` → 536 passing (was 518 before; +18 awareness loop, +5 routing, +1 `_battle_mode_group`).
- [x] Replay harness ran 3 full passes against live db: 10/10 scenarios clean, 0 validation issues, 0 uncovered hard-post floors.
- [ ] Watch `elixir.log` for the first hour after the next deploy — fast-path skip rate, agent latency, fallback frequency.
- [ ] Confirm #trophy-road carries only battle-mode signals over a week; #player-progress carries only durable milestones.
- [ ] Confirm the v4.5 capability_unlock posts to #announcements on next bot restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)