### PR TITLE
Event Core v5: reactive, event-sourced architecture (design doc)

### DIFF
--- a/docs/tasks/elixir-event-sourcing-migration.md
+++ b/docs/tasks/elixir-event-sourcing-migration.md
@@ -1,84 +1,100 @@
-# Plan: Elixir Event Core Rewrite
+# Plan: Elixir Event Core (v5) — Event-Sourced, Reactive Architecture
 
 Status: Design plan. Original tracking issue: #95. Boundary refinement: #97.
 
-Captured: 2026-06-21.
+Captured: 2026-06-21. Revised: 2026-06-21 (library adoption, reactive v5 framing,
+two-context aggregate model, UTC-only, single-campaign migration).
 
-This plan supersedes the earlier "stream as observation substrate" framing in
-`docs/tasks/elixir-stream-redesign-direction.md` and nests the implemented
-stream work into a fuller event-sourcing architecture. The prior work was a
-necessary step: battles and selected detector signals now land in
-`game_event_stream`, and Situation can read stream summaries.
+This plan supersedes the "stream as observation substrate" framing in
+`docs/tasks/elixir-stream-redesign-direction.md`. The prior work was a necessary
+step — battles and selected detector signals now land in `game_event_stream`, and
+Situation can read stream summaries. This plan nests that work into a fuller
+event-sourcing architecture and changes the runtime model along with the data
+model.
 
-The next target is larger: rewrite Elixir's core data substrate so the event log
-is the authoritative record of observed state changes, derived observations,
-leadership recommendations, and case decisions. This is a core data rewrite, not
-a bot rewrite. Runtime surfaces, prompt workflows, and external side-effect
-layers should consume projections from the Event Core; they should not define
-the Event Core's schema.
+The target is not "add an event log next to the current system." It is to make
+the event log the **authoritative internal record** of everything Elixir
+observes, infers, and decides, and to make Elixir **react to events** instead of
+waking on a schedule and guessing what mattered. This is a core rewrite of
+Elixir's data and control substrate. It is done once, as a whole, on an isolated
+copy, and cut over atomically. There is no second consumer of this system, so
+there is **no backward-compatibility layer**.
 
-## Purpose
+---
 
-Elixir should be able to ask and answer questions like:
+## 1. The v5 Thesis: from scheduled awareness to event-driven action
 
-- What changed for this player over the last 7, 28, 56, or 90 days?
-- Which players got the same achievement or badge this week?
-- Which cards are moving across the clan?
-- Which members are active in Ranked / Path of Legends, 2v2, special events,
-  Trophy Road, and River Race?
-- Which state changes caused a streak, a promotion candidate, a demotion
-  candidate, or a kick review?
-- Which leadership recommendations were generated, refreshed, suppressed, or
-  resolved, and what evidence caused them?
+Today Elixir wakes on a timer, assembles a large "Situation" blob of everything
+it might care about this tick, and asks an agent to find something worth saying.
+The schedule drives the bot; the data is a passive lookup.
 
-The current model can answer some of this from a mix of fact tables, signal
-events, rollups, decision cases, leader-action side tables, and awareness
-telemetry. That mix is useful, but not coherent. The same fact can be
-represented in several places, and many ordinary state changes are not events at
-all unless a detector decides they are notable.
+v5 inverts this. **Events drive the bot.** When ingest observes that a player did
+something, that observation becomes an event. When an aggregator notices a
+pattern (a hot streak, a badge wave, a promotion-worthy contribution), it emits a
+derived event. The *arrival of a noteworthy event* is what triggers Elixir to
+act — to post about a player's achievement, to open a leadership case, to flag a
+risk. Elixir becomes reactive to what the clan is **doing**, not to the clock.
 
-The event-sourcing target is:
+Two trigger sources remain, in deliberate proportion:
 
-```
-External snapshots / commands
-  -> observed domain events
-  -> projections and aggregators
-  -> derived events
-  -> leadership recommendation events
-  -> case projections and decision events
-```
+- **Reactive (primary).** A process application follows the event log. When a
+  derived or recommendation event of a noteworthy class lands, that event — with
+  its own evidence links — is the trigger. This is the engine.
+- **Cadence (secondary, small).** A short list of genuinely periodic reflections
+  ("comment on clan activity in the last 24 hours") stays time-triggered, but
+  these **query projections**; they do not assemble signal batches. This is the
+  exception, not the model.
 
-In this model, "signals" are no longer the primary unit of awareness. They become
-derived stream events or recommendation events emitted by aggregators.
+Consequences for the old design:
 
-## Core Decision
+- **"Situation" as a pre-computed per-tick blob is retired.** It was an artifact
+  of schedule-first operation. In v5 the triggering event already knows what
+  mattered. What survives is a thin, on-demand **context query service** over
+  projections, called *by a trigger* when Elixir decides to act and needs
+  surrounding detail to write well. There is no "Situation V2."
+- Signals stop being the primary unit of awareness. They become derived events
+  emitted by aggregators.
 
-Elixir's event log is the authoritative internal history of Elixir's observed
-world.
+---
 
-The Clash Royale API remains the authoritative upstream source for current game
-state. It is not Elixir's event store. It is an external snapshot source that
-Elixir samples, diffs, and converts into observed events.
+## 2. Core Decisions (firm)
 
-Plain-language distinction:
+These are settled. They close several previously-open questions.
 
-- **CR API snapshot**: what Supercell currently says is true.
-- **Observed event**: what Elixir observed changed, when it observed it, and what
-  upstream evidence caused that observation.
-- **Projection**: Elixir's query-optimized view derived from events.
-- **Derived event**: an event emitted by an aggregator after reading other
-  events or projections.
-- **Recommendation event**: a leadership-private derived event that says Elixir
-  recommends or suppresses action for a member, with evidence links and policy
-  version.
-- **Case projection**: the current lifecycle state of a recommendation or
-  concern, derived from recommendation and case-decision events.
+1. **The event log is Elixir's authoritative internal history.** The Clash Royale
+   API is the authoritative *upstream* source of current game state. It is not
+   Elixir's event store. It is an external snapshot source Elixir samples, diffs,
+   and converts into observed events.
 
-## Core Boundary
+2. **Adopt the Python `eventsourcing` library with its SQLite backend.** We are
+   committing to the full model and to growing use of it; the library gives us the
+   exact machinery this design leans on (see §4). We build native domain
+   aggregates *on* the library, not a hand-rolled event store.
 
-The Event Core is a data model. It should not contain presentation logic.
+3. **Two bounded contexts** (see §5): the **Observed World** (game-domain
+   observation aggregates, written only by ingest) and **Elixir's Mind** (Elixir's
+   inferences and decisions, written only by stream followers). Member and
+   WarSeason live in the World; Recommendation and DecisionCase live in the Mind.
+   The Mind reads the World; the World never reads the Mind.
 
-Do not put these concepts in the authoritative event stream:
+4. **UTC everywhere in the data layer.** Events, payloads, and projections store
+   time in UTC (CR API time is already Zulu). No `America/Chicago` anywhere in the
+   event core. Timezone conversion happens only at presentation/rollup read time,
+   in exactly one isolated place (see §7).
+
+5. **Single-campaign rewrite, no backward compatibility.** The whole model is
+   built on an isolated copy of the repo and database, validated by replay and a
+   one-time parity check, then cut over atomically. No compatibility consumers, no
+   shim functions, no dual-running. Backward compatibility is dead weight when
+   there is one user and the upstream truth (CR API) is always re-derivable.
+
+---
+
+## 3. Core Boundary
+
+The Event Core is a data and reasoning model. It contains no presentation logic.
+
+Never put in the event store:
 
 - external surface routing identifiers
 - rendering component identifiers, layouts, action states, or final copy
@@ -86,865 +102,530 @@ Do not put these concepts in the authoritative event stream:
 - external publishing formatting details
 - presentation-specific routing policy
 
-Those belong in downstream read models that consume Event Core projections. The
-Event Core may record that a leadership recommendation was generated,
-suppressed, accepted, rejected, deferred, or resolved. It should not record the
-form used to surface that recommendation.
+Those belong in downstream side-effect surfaces that **consume** Event Core
+projections. The core may record that Elixir *decided to communicate* something
+(a communication-intent event, see §8) or that a recommendation was generated,
+suppressed, accepted, rejected, deferred, or resolved. It must not record the
+form used to surface any of it.
 
-## Architectural Gap
-
-Today `game_event_stream` is mostly:
-
-- one row per observed battle (`event_class='battle'`)
-- one row per selected detector signal (`event_class='signal'`)
-
-That is not yet event sourcing. It is a hybrid observation ledger.
-
-Missing pieces:
-
-1. Ordinary player state changes are not always events.
-   A card can move from level 12 to 13 without an event because Elixir only emits
-   `card_level_milestone` when a configured threshold is crossed.
-
-2. Signals combine detection, derivation, and actionability policy.
-   A streak is currently a signal. In the target model it is a derived event,
-   caused by battle events, that may or may not feed a recommendation, case, or
-   other downstream policy decision.
-
-3. Projection ownership is unclear.
-   Tables like `member_current_state`, card snapshots, war tables, daily metrics,
-   decision cases, and leader-action side tables are currently partial ledgers.
-   In the target model, they are projections or downstream side-effect records.
-
-4. Leadership recommendations are a side system.
-   Promotion, demotion, and kick recommendations are currently produced by a
-   recompute-first scan. They should instead be generated by stream consumers and
-   inserted into the same event store as leadership-private recommendation
-   events.
-
-5. Filters and cohort views are bolted on after the fact.
-   The stream needs first-class dimensions for player, card, badge, achievement,
-   battle mode, war season, local date, scope, and source.
-
-## Target Architecture
-
-### 1. Event Store
-
-Append-only durable event log. This can evolve from `game_event_stream` or move
-to a new table such as `domain_events`. The important change is conceptual:
-events become the write model, not a sidecar.
-
-Required properties:
-
-- Append-only: no updating payloads in place.
-- Globally ordered: every event has a monotonically increasing global position.
-- Idempotent: repeated ingest of the same upstream observation produces the same
-  event key and no duplicate event.
-- Causally linked: derived events point to the base events that caused them.
-- Scoped: public, leadership, and system-internal data are separated structurally.
-- Versioned: event schemas have versions and can be upcast.
-- Queryable by dimensions without unpacking every payload.
-
-### 2. Snapshot Ingest
-
-Snapshot ingest reads external state and emits base events.
-
-For example:
+Directional dependency, enforced by construction:
 
 ```
-CR player profile snapshot
-  -> player_profile_observed
-  -> player_name_changed
-  -> player_trophies_changed
-  -> player_best_trophies_changed
-  -> ranked_league_changed
-  -> card_level_changed
-  -> badge_level_changed
-  -> achievement_stars_changed
+CR API (upstream truth)
+  -> Observed World aggregates        (ingest writes)
+  -> Elixir's Mind aggregates         (followers write, reading the World)
+  -> side-effect surfaces             (read projections of the Mind; write nothing back)
 ```
 
-Battle-log ingest emits:
+---
 
-```
-battle_played
-```
+## 4. Architecture on the `eventsourcing` library
 
-Roster ingest emits:
+The library is aggregate-centric: an **aggregate** is a consistency boundary with
+its own event-sequenced history keyed by a stable ID, reconstructed by replaying
+its events. This is a different shape from the old "one wide event table" plan,
+and the difference matters (see §4.2).
 
-```
-member_joined
-member_left
-member_role_changed
-member_donations_changed
-member_war_preference_changed
-```
+### 4.1 What the library gives us
 
-War ingest emits:
+The three properties that become load-bearing once compatibility shims are gone
+are provided directly:
 
-```
-war_season_observed
-war_period_started
-war_period_completed
-war_rank_changed
-war_member_decks_used_changed
-war_member_fame_changed
-```
+- **Gap-free global ordering** → the **notification log**
+  (`app.notification_log.select(start=n, limit=m)`). This *is* the
+  `global_position` the old plan was going to hand-roll, correct under SQLite
+  locking instead of a hand-built sequence table.
+- **Reliable consumers** → **process applications** (`Follower`) maintain
+  **tracking records** of how far they have read. Exactly-once consumption,
+  replayable. This replaces `signal_detector_cursors` and the planned consumer
+  table.
+- **Schema evolution** → built-in **upcasting** of versioned events.
 
-### 3. Projections
+SQLite environment (per the library tutorial, part 3):
 
-Projection tables are deterministic read models derived from the event log.
+- `PERSISTENCE_MODULE = 'eventsourcing.sqlite'`
+- `SQLITE_DBNAME = '/path/to/elixir-events.db'` — the event store gets its **own
+  file**, separate from the projection/read-model DB (today's `elixir.db`). Keep
+  the library's opaque write store apart from queryable projections.
+- `SQLITE_LOCK_TIMEOUT` — optional, default 5s.
+- Tests use the in-memory form `'file::memory:?mode=memory&cache=shared'`.
 
-Current tables that should become projections:
+Stored events are neither compressed nor encrypted by default; leadership-scoped
+payloads that need protection must be handled explicitly (see Guardrails).
 
-| Projection | Purpose |
+### 4.2 The reshape: the store is opaque; dimensions live in projections
+
+The library stores events as serialized payloads **per aggregate sequence**. You
+**cannot** run `WHERE card_key = ? across all members` against the event store.
+This kills the old "Event Model" section's wide, 30-column, denormalized
+`domain_events` table with dimensional indexes. That table does not exist in this
+design.
+
+Instead, the old table's two jobs split cleanly along CQRS lines:
+
+- **Write model** = the library's event store (opaque, per-aggregate, append-only,
+  globally ordered via the notification log).
+- **Read model** = purpose-built **projection tables** in `elixir.db`, maintained
+  by follower process applications. Every "filtered view" the old plan wanted
+  (player timeline, card movement, badge cohort, battle-mode, war season,
+  recommendation/case audit) becomes a projection with exactly the columns and
+  indexes that view needs.
+
+This is more correct CQRS, not a compromise. It also means the existing
+`storage/event_stream.py` (the 612-line hand-rolled append helper) and the
+`game_event_stream` table are **replaced**, not evolved.
+
+---
+
+## 5. The Aggregate Model
+
+The central design question — answered with the CR API surface in hand — is *what
+are the aggregates?* The answer falls into two bounded contexts.
+
+### 5.1 Bounded context A — the Observed World (written only by ingest)
+
+These aggregates record **observations of external game reality**. Their events
+are of the form "we observed X changed, when, and from what upstream evidence."
+They are written exclusively by snapshot ingest. They never contain inference or
+decision.
+
+| Aggregate | Key | Lifecycle | Notes |
+|---|---|---|---|
+| **Player** | `player_tag` | durable, slow-changing | Primary anchor. Profile/card/badge/achievement/ranked progression. Carries embedded *foreign*-season snapshots (league stats, PoL results) that are projections of the season aggregates, not Player's own lifecycle. Keep lean — do **not** replay battles to reconstruct it (see §5.3). |
+| **Clan** | `clan_tag` | durable, slow-changing | Second anchor. Clan-wide state plus **roster membership lifecycle** (joined/left/role-changed) as Clan events — roster is a Clan invariant. |
+| **RiverRace** (weekly war) | `(clan_tag, riverRaceSeasonId, sectionIndex)` | training → warDay → colosseum → `finishTime` | The strongest lifecycle in the API. The **week** is the aggregate boundary, not the multi-week "season." `currentriverrace` is the in-flight view; the `riverracelog` entry is the terminal state. ⚠ `riverRaceSeasonId` is a **sequential integer** — a different keyspace from the league season's `YYYY-MM`. |
+| **LeagueSeason** (ranked/PoL) | `seasonId` = `YYYY-MM` | monthly start → end | The canonical ranked/league cycle. Player `leagueStatistics` and PoL season results are projections referencing this key. |
+| **Tournament** (player-created) | `tournament_tag` | inPreparation → inProgress → ended | Bounded lifecycle with a terminal state and `created/started/endedTime`. Capture final `membersList` on the `ended` transition. Linked battle facts rotate out of battle logs fast — capture promptly. |
+| **SpecialEvent** | `eventTag` | appeared → disappeared (**inferred** from polling) | `/events` exposes no start/end timestamps, only presence. Model an appear/disappear lifecycle inferred from polling; play-facts arrive via `Battle.eventTag`. |
+| **GlobalTournament** (optional) | `tournament_tag` | `startTime` → `endTime` | Supercell-run; usually absent in sampling. Low priority — include only if/when populated. |
+
+**Facts, not aggregates** (high-volume, immutable, externally authored — they feed
+projections, they are not consistency boundaries):
+
+- **Battle** — the core fact stream. Dedup key = `battleTime` + sorted
+  `(team[0].tag, opponent[0].tag)`. **Game mode is a field on the battle**
+  (`gameMode.id`/`name`, `type`), not an aggregate. ⚠ battle logs are a rolling
+  ~30-battle window — facts are lost if not captured promptly.
+- **Rankings / leaderboards / upcoming chests** — point-in-time snapshots. Ingest
+  as snapshot facts attached to the relevant location/season/mode key.
+
+**Reference data** (slowly-changing global catalogs — versioned static snapshots,
+not per-entity aggregates):
+
+- **Card catalog** (`/cards`), **Locations** (`/locations`).
+
+### 5.2 Bounded context B — Elixir's Mind (written only by followers)
+
+This is your DecisionCase/Recommendation insight generalized. These aggregates are
+**not part of the game**. They are Elixir's own inferences and decisions. They are
+written exclusively by process applications that follow the World's notification
+log, and every event they emit carries `caused_by` links pointing back at the
+World events that justified it. They are true behavioral aggregates with
+invariants and command-driven state machines — unlike World aggregates, which only
+record observations.
+
+| Aggregate | Key | Lifecycle | Notes |
+|---|---|---|---|
+| **Detection** | detection id | detected → (refreshed) → expired/superseded | Derived observations: hot streak, slump, trophy push, ranked surge, cohort badge/achievement wave, card-upgrade wave, inactive-member risk, war momentum shift, clan record. Replaces "signals." Each carries `caused_by_event_ids`. |
+| **Recommendation** | recommendation id | detected → refreshed → suppressed/expired → outcome observed | Promotion / demotion / kick / watch / no-action. Real invariants (cannot refresh an expired recommendation). Carries `recommendation_type`, `reason_codes`, `policy_version`, `confidence`/`severity`, `scope='leadership'`, evidence links. |
+| **DecisionCase** | case id | opened → refreshed → deferred → accepted/rejected/resolved | The leadership decision state machine. Real invariants (cannot accept a resolved case). Deferred cases resurface because case state says they are due. |
+
+The split answers the user's instinct directly: **Member/Clan/RiverRace/LeagueSeason
+are the Observed World** (game reality Elixir watches); **Detection/Recommendation/
+DecisionCase are Elixir's Mind** (what Elixir concludes and decides). Side-effect
+surfaces (Discord posts) read the Mind and write nothing back.
+
+This also resolves writer-concurrency cleanly: **ingest is the single writer to
+the World; each follower owns its own Mind aggregates.** No aggregate has two
+writers, so optimistic-version contention is avoided by construction.
+
+### 5.3 Two design decisions this model forces (gating — see §12)
+
+1. **Where do battles live in a library that requires aggregates?** Everything in
+   the notification log must be an aggregate event, but a Player aggregate that
+   replays thousands of `BattleObserved` events on every load is wrong.
+   - *Recommended:* a per-ingest-run **`BattlesObserved` summary event** (on
+     Player or a thin `ClanActivity` aggregate) that references a batch, while raw
+     battle rows land directly in a **battle-fact projection table** in `elixir.db`
+     where they are queryable by mode/time. The log stays lean; the high-volume
+     data stays in SQL.
+   - *Alternative:* a dedicated per-player `BattleLog` aggregate, never
+     reconstructed, consumed forward-only by followers (lean Player aggregate, but
+     a high-volume sequence in the library store).
+   - Decide in Phase 0. This is the one place library purity has a real cost.
+
+2. **Where do derived events live?** Derived events are Mind events, so they live
+   on **Detection / Recommendation / DecisionCase aggregates**, not back on the
+   Player. The unified "Player Timeline" view (observations + inferences about one
+   player) is reassembled as a **projection** that merges World events for
+   `player_tag` with Mind events whose subject is that player. This keeps every
+   aggregate single-writer and uses the projection layer we are building anyway.
+
+### 5.4 Why game modes are NOT aggregates
+
+Game *modes* (Trophy Road / Path of Legends / 2v2 / Touchdown / CHAOS / special
+events) have no stable identity and no start→end lifecycle of their own. A mode is
+a **category of battle facts**, expressed as `gameMode.id`/`type` on the Battle
+fact and as a **dimension** on battle projections. Modeling each mode as an
+aggregate would invent identity where the API has none.
+
+What *does* deserve a period aggregate is anything with a key and a lifecycle:
+River Race week, league season, tournaments, special events. That is the line:
+**mode = dimension; bounded cycle = aggregate.**
+
+---
+
+## 6. Mapping current tables to the new model
+
+| Current table(s) | Becomes |
 |---|---|
-| `members`, `member_current_state` | latest roster identity and current member state |
-| `player_profile_snapshots` or successor | latest and historical sampled profile views |
-| card collection tables | current card levels/evolutions plus history |
-| badge / achievement views | current badge and achievement state |
-| `member_battle_facts` | battle-detail read model and battle query accelerator |
-| `member_daily_metrics` | daily player summaries |
-| war tables | war-season and war-period read models |
-| `event_rollups` | durable summaries beyond the high-fidelity retention window |
-| `decision_cases` | current unresolved concern state |
+| `game_event_stream` (12.5k battle + 54 signal rows), `storage/event_stream.py` | **Removed.** Replaced by the library event store + projections. |
+| `members`, `member_current_state`, `clan_memberships`, `member_metadata`, `member_aliases` | **Projections** of Player + Clan aggregates. |
+| `player_profile_snapshots`, `member_state_snapshots`, `member_card_collection_snapshots`, `member_card_usage_snapshots`, `member_deck_snapshots` | **Upstream sample archive** (ingest source) and/or **projections**; role made explicit per table. |
+| `member_battle_facts`, `tournament_battles`, `member_recent_form` | **Battle-fact projection(s)** (see §5.3). |
+| `member_daily_metrics`, `clan_daily_metrics`, `member_daily_battle_rollups`, `clan_daily_battle_rollups`, `event_rollups` | **Rollup projections** — the one place TZ enters (see §7). |
+| `war_current_state`, `war_day_status`, `war_period_clan_status`, `war_races`, `war_participation`, `war_participant_snapshots`, `clan_voyages`, `clan_voyage_entries` | **RiverRace** aggregate + war projections. |
+| `tournaments`, `tournament_participants` | **Tournament** aggregate + projections. |
+| `card_catalog`, `game_mode_contexts` | **Reference data** (versioned static snapshots). |
+| `signal_log`, `signal_outcomes`, `signal_detector_cursors`, `signal_keys.py` | **Removed / replaced** by Detection aggregates + library tracking records. |
+| `decision_cases`, `leader_action_recommendations`, `revisits` | **DecisionCase** + **Recommendation** aggregates (the Mind). |
+| `communication_intents`, `communication_intent_event_links` | Communication-intent events (Mind→surface boundary, see §8) + a side-effect surface read model. |
+| `raw_api_payloads`, `arena_relay_screenshot_observations`, `api_sentinel_observations` | **Backfill/ingest sources** (see §10) + observation events. |
+| `awareness_ticks` | Reframed/retired — the schedule-first awareness loop is replaced by reactive triggers + a small cadence set (§8). |
 
-Some existing tables may remain as source snapshots during migration. The end
-state should make their role explicit: either upstream sample archive or
-projection from events.
+Memory/embedding tables (`clan_memories*`, `memory_*`), Discord plumbing
+(`discord_*`, `messages`, `channel_state`, `conversation_threads`), `llm_calls`,
+and improvement/project tracking are **outside** the Event Core. They may consume
+projections; they are not part of this model.
 
-External side-effect tables are outside the Event Core. They may consume Event
-Core projections, but they are not authoritative sources for player, roster,
-recommendation, or case state.
+---
 
-### 4. Aggregators
+## 7. Projections and read models (UTC storage, TZ only at read)
 
-Aggregators consume events/projections and emit derived events.
+Projection tables are deterministic read models, each maintained by a follower
+process application with its own tracking record. They are rebuildable from the
+event log on a copy.
 
-Examples:
+Storage is **UTC**. `local_date` is **removed from the data layer entirely** — it
+was presentation logic smuggled into storage, in violation of §3.
+
+The single unavoidable timezone boundary is **daily rollups** (`member_daily_*`,
+`clan_daily_*`). A human "today" is a Chicago day. The rule:
+
+- Daily-rollup projections compute the Chicago day boundary **at projection/read
+  time, from UTC events**, as an explicit, parameterized presentation choice.
+- The timezone (`America/Chicago`) appears in exactly **one** isolated module used
+  by rollup projections. No event, no payload, no World/Mind aggregate ever knows
+  what Chicago is.
+
+Initial projection set (built in roughly this order of risk):
+
+- per-player current state; per-card current state; per-badge/achievement state
+- per-mode battle summary (the battle-fact projection)
+- player timeline (World + Mind merge by `player_tag`)
+- cohort views (badge/achievement/card by dimension)
+- war-season views (RiverRace projections)
+- recommendation/case audit view (Mind aggregates)
+- daily rollups (TZ-aware, isolated)
+
+---
+
+## 8. Aggregators and the reactive trigger path
+
+Aggregators are **process applications** (`Follower`) that consume the
+notification log with tracking and emit derived (Mind) events. The key rule
+holds: **aggregators do not post; they emit events.**
+
+Examples (consume → emit):
 
 | Aggregator | Consumes | Emits |
 |---|---|---|
-| battle streak detector | `battle_played` | `battle_hot_streak_detected`, `battle_slump_detected` |
-| ranked pulse detector | ranked `battle_played`, `ranked_league_changed` | `ranked_activity_surge_detected`, `ranked_climb_detected` |
+| battle streak detector | battle-fact events | `battle_hot_streak_detected`, `battle_slump_detected` |
+| ranked pulse detector | ranked battles, `ranked_league_changed` | `ranked_activity_surge_detected`, `ranked_climb_detected` |
 | cohort badge detector | `badge_earned`, `badge_level_changed` | `cohort_badge_wave_detected` |
 | card movement detector | `card_unlocked`, `card_level_changed`, `card_evolution_changed` | `card_upgrade_wave_detected`, `new_champion_wave_detected` |
 | roster health detector | roster/player/war events | `inactive_member_risk_detected` |
-| leadership recommendation generator | roster/player/war/ranked/case events | `promotion_candidate_detected`, `demotion_candidate_detected`, `kick_candidate_detected`, `leadership_recommendation_suppressed` |
-| war momentum detector | war period/member events | `war_momentum_shift_detected`, `war_recovery_needed_detected` |
-
-The key rule: aggregators do not directly post. They emit events.
-
-Leadership recommendation generators are aggregators. They consume the same event
-stream as every other generator, emit leadership-scoped derived events, and link
-each recommendation to its evidence events. They are not a separate side system.
-
-### 5. Situation Builder
-
-Situation becomes a stream query and projection assembly layer.
-
-It should read:
-
-- recent base events by scope/window
-- recent derived events by priority
-- cohort clusters by dimension
-- due cases
-- due revisits represented as case reminders
-- recent recommendation and case events
-- projection snapshots for compact context
-
-It should not depend on ephemeral signal batches as its main model. A current
-tick can still pass newly emitted events into Situation, but the agent should
-understand them as "new event positions since last run," not as special signal
-objects.
-
-### 6. Leadership Recommendations and Cases
-
-Leadership recommendations are part of the Event Core.
-
-Target flow:
-
-```
-base and derived events
-  -> promotion_candidate_detected | demotion_candidate_detected | kick_candidate_detected
-  -> leadership_recommendation_refreshed | leadership_recommendation_suppressed
-  -> decision_case_opened | decision_case_refreshed
-  -> decision_case_deferred | decision_case_accepted | decision_case_rejected | decision_case_resolved
-  -> recommendation_outcome_observed
-```
-
-The case table is a projection of these events. It answers "what is currently
-open, due, deferred, resolved, or measured?" The event store answers "what
-happened, what policy generated it, and what evidence caused it?"
-
-Recommendation events should carry:
-
-- `player_tag`
-- `recommendation_type`: promotion, demotion, kick, watch, no_action
-- `reason_codes`: inactivity, low war participation, elder readiness,
-  sustained contribution, role mismatch, etc.
-- `policy_version`
-- `confidence` or `severity`
-- `scope='leadership'`
-- `caused_by_event_ids_json`
-
-External consumers can project these cases into whatever surface they own. That
-projection must not leak surface-specific concepts back into the Event Core.
-
-## Event Model
-
-Minimum event columns:
-
-| Column | Purpose |
-|---|---|
-| `event_id` | local row id |
-| `global_position` | ordered application sequence |
-| `event_key` | deterministic idempotency key |
-| `event_type` | domain event type |
-| `event_family` | player, card, badge, achievement, battle, war, roster, recommendation, case, system |
-| `event_class` | base, derived, recommendation, case, system |
-| `schema_version` | payload version |
-| `source_system` | player_intel, clan_awareness, war_awareness, recommendation_generator, case_manager, manual, system |
-| `source_detector` | emitter/aggregator name |
-| `occurred_at` | when the underlying thing happened, if known |
-| `observed_at` | when Elixir observed it |
-| `recorded_at` | when Elixir appended it |
-| `local_date` | America/Chicago date for day-level filters |
-| `scope` | public, leadership, system_internal |
-| `subject_type` | member, clan, card, badge, achievement, battle_mode, war, case, recommendation, system |
-| `subject_key` | primary subject key |
-| `actor_type` | optional actor, usually member or elixir |
-| `actor_key` | player tag, stable human identifier, or Elixir component |
-| `clan_tag` | clan dimension |
-| `player_tag` | denormalized member dimension |
-| `card_key` | denormalized card dimension |
-| `badge_key` | denormalized badge dimension |
-| `achievement_key` | denormalized achievement dimension |
-| `game_mode` | ladder, ranked, two_v_two, special_event, tournament, friendly, war, other |
-| `battle_type` | Clash Royale battle type when relevant |
-| `season_id` | war/ranked/game season dimension |
-| `war_week` | war week/section dimension |
-| `correlation_id` | groups events from one ingest run or decision chain |
-| `causation_id` | immediate parent event |
-| `caused_by_event_ids_json` | derived-event evidence list |
-| `payload_json` | compact event payload |
-| `payload_hash` | integrity/dedupe support |
-
-Indexes should support:
-
-- global position scans
-- event type + time
-- local date + event family
-- scope + time
-- player + time
-- card + time
-- badge + time
-- achievement + time
-- game mode + time
-- season/week + time
-- event family/class + time
-- correlation/causation lookup
-
-## Event Taxonomy
-
-### Player and Roster Base Events
-
-- `player_profile_observed`
-- `player_name_changed`
-- `player_experience_changed`
-- `player_level_changed`
-- `player_trophies_changed`
-- `player_best_trophies_changed`
-- `player_wins_changed`
-- `player_losses_changed`
-- `player_battle_count_changed`
-- `player_donations_changed`
-- `player_war_day_wins_changed`
-- `player_challenge_best_changed`
-- `member_joined`
-- `member_left`
-- `member_role_changed`
-- `member_active_again_observed`
-- `member_inactivity_observed`
-
-### Ranked / Path of Legends Base Events
-
-- `ranked_season_result_observed`
-- `ranked_league_changed`
-- `ranked_trophies_changed`
-- `ranked_global_rank_changed`
-- `ultimate_champion_status_changed`
-
-### Card Base Events
-
-- `card_collection_observed`
-- `card_unlocked`
-- `card_level_changed`
-- `card_level_milestone_crossed`
-- `card_evolution_changed`
-- `card_current_deck_changed`
-- `card_usage_observed`
-
-`card_level_milestone_crossed` can be either a base event emitted during diffing
-or a derived event from `card_level_changed`. Prefer derived if we want every
-ordinary card change recorded first.
-
-### Badge and Achievement Base Events
-
-- `badge_collection_observed`
-- `badge_earned`
-- `badge_level_changed`
-- `achievement_observed`
-- `achievement_stars_changed`
-- `achievement_completed`
-
-### Battle Base Events
-
-- `battle_played`
-- `battle_deck_observed`
-- `battle_opponent_observed`
-
-`battle_played` remains high-volume and must not be inserted raw into prompts.
-It feeds projections, rollups, and aggregators.
-
-### War Base Events
-
-- `war_state_observed`
-- `war_season_started`
-- `war_season_completed`
-- `war_week_started`
-- `war_week_completed`
-- `war_period_started`
-- `war_period_completed`
-- `war_rank_changed`
-- `war_fame_changed`
-- `war_member_participation_changed`
-- `war_member_decks_used_changed`
-- `war_rival_activity_changed`
-
-### Derived Events
-
-- `battle_hot_streak_detected`
-- `battle_slump_detected`
-- `battle_trophy_push_detected`
-- `ranked_activity_surge_detected`
-- `ranked_climb_detected`
-- `cohort_badge_wave_detected`
-- `cohort_achievement_wave_detected`
-- `card_upgrade_wave_detected`
-- `new_card_unlock_wave_detected`
-- `inactive_member_risk_detected`
-- `war_momentum_shift_detected`
-- `war_recovery_needed_detected`
-- `clan_record_detected`
-- `season_award_granted`
-
-### Leadership Recommendation Events
-
-- `promotion_candidate_detected`
-- `demotion_candidate_detected`
-- `kick_candidate_detected`
-- `leadership_recommendation_refreshed`
-- `leadership_recommendation_suppressed`
-- `leadership_recommendation_expired`
-- `recommendation_outcome_observed`
-
-### Case Decision Events
-
-- `decision_case_opened`
-- `decision_case_refreshed`
-- `decision_case_deferred`
-- `decision_case_accepted`
-- `decision_case_rejected`
-- `decision_case_resolved`
-
-### System Observation Events
-
-- `runtime_job_started`
-- `runtime_job_succeeded`
-- `runtime_job_failed`
-- `api_schema_shape_observed`
-- `api_schema_sentinel_emitted`
-
-## Filtered Views and Aggregates
-
-The event model should make these views straightforward.
-
-### Player Timeline
-
-Filter:
-
-- `player_tag = ?`
-- `event_family IN (...)`
-- time window
-
-Answers:
-
-- player changed name
-- player climbed in ranked
-- player upgraded cards
-- player earned badges
-- player battled in each mode
-- Elixir opened/resolved cases about player
-- Elixir generated, suppressed, or resolved leadership recommendations about
-  player
-
-### Achievement / Badge Cohort View
+| war momentum detector | RiverRace period/member events | `war_momentum_shift_detected`, `war_recovery_needed_detected` |
+| recommendation generator | roster/player/war/ranked/case events | `promotion_candidate_detected`, `demotion_candidate_detected`, `kick_candidate_detected`, `leadership_recommendation_suppressed` |
 
-Filter:
+The **reactive trigger** is itself a follower — a **communication policy** process
+application. When a noteworthy Detection or Recommendation event lands, the policy
+decides whether it warrants action and emits a **communication-intent** event. The
+intent is the Mind→surface boundary: the *decision to communicate* is in the core
+(scoped public/leadership); the *post, its copy, formatting, and delivery* are the
+side-effect surface, outside the core. Existing `communication_intents` is that
+surface's read model.
 
-- `achievement_key = ?` or `badge_key = ?`
-- event type `achievement_stars_changed`, `achievement_completed`,
-  `badge_earned`, `badge_level_changed`
-- time window
+Cadence reflections ("24h clan summary") are a small, separate scheduled follower
+that queries projections — not a return of schedule-first awareness.
 
-Answers:
+---
 
-- 10 players got the same achievement
-- 4 players leveled the same mastery badge
-- a seasonal event badge is spreading through the clan
+## 9. Event taxonomy
 
-### Card Movement View
+Organized by context and aggregate. (Largely preserved from the prior plan; types
+are unchanged in spirit, re-homed onto aggregates.)
 
-Filter:
-
-- `card_key = ?`
-- event type `card_unlocked`, `card_level_changed`,
-  `card_evolution_changed`
-
-Answers:
-
-- which members unlocked a new champion
-- which cards are becoming level 16
-- which evolutions are appearing
-- whether card movement correlates with battle-mode success
+### Observed World — Player aggregate
 
-### Battle-Mode View
+`player_profile_observed`, `player_name_changed`, `player_experience_changed`,
+`player_level_changed`, `player_trophies_changed`, `player_best_trophies_changed`,
+`player_wins_changed`, `player_losses_changed`, `player_battle_count_changed`,
+`player_donations_changed`, `player_war_day_wins_changed`,
+`player_challenge_best_changed`.
 
-Filter:
+Ranked / Path of Legends: `ranked_season_result_observed`,
+`ranked_league_changed`, `ranked_trophies_changed`, `ranked_global_rank_changed`,
+`ultimate_champion_status_changed`.
 
-- `game_mode = ranked | ladder | two_v_two | special_event | war`
-- event type `battle_played` plus derived battle events
+Cards: `card_collection_observed`, `card_unlocked`, `card_level_changed`,
+`card_level_milestone_crossed` (prefer derived), `card_evolution_changed`,
+`card_current_deck_changed`, `card_usage_observed`.
 
-Answers:
+Badges/achievements: `badge_collection_observed`, `badge_earned`,
+`badge_level_changed`, `achievement_observed`, `achievement_stars_changed`,
+`achievement_completed`.
 
-- who is grinding Path of Legends this week
-- which players are driving 2v2 activity
-- whether a special event has unusual participation
-- whether ranked activity is broad or isolated to one player
-
-### War Season View
-
-Filter:
-
-- `season_id = ?`
-- war event families
-
-Answers:
-
-- week-by-week rank/fame trajectory
-- member participation deltas
-- rival movement
-- war awards and leadership recommendations caused by war evidence
-
-### Leadership Recommendation and Case Audit View
-
-Filter:
+### Observed World — Clan aggregate (roster)
 
-- `event_family IN ('recommendation', 'case')`
-- optional player/card/badge/mode dimensions
+`member_joined`, `member_left`, `member_role_changed`,
+`member_active_again_observed`, `member_inactivity_observed`,
+`member_donations_changed`.
 
-Answers:
-
-- what Elixir saw
-- why Elixir recommended promotion, demotion, kick, watch, or no action
-- why Elixir suppressed a recommendation
-- which event cluster caused a case to open or refresh
-- how the case was accepted, rejected, deferred, resolved, or measured
+### Observed World — Battle facts
 
-## Relationship to the `eventsourcing` Library
-
-The event-sourcing architecture should align with the concepts in the Python
-`eventsourcing` project:
+`battle_played` (high-volume; never injected raw into prompts — feeds projections,
+rollups, aggregators), `battle_deck_observed`, `battle_opponent_observed`. See
+§5.3 for how these enter the log.
 
-- aggregate sequences
-- application-wide notification log
-- projections/materialized views
-- process applications
-- tracking records for reliable consumers
-- versioned/upcastable events
+### Observed World — RiverRace aggregate
 
-Reference:
+`war_state_observed`, `war_season_started`, `war_season_completed`,
+`war_week_started`, `war_week_completed`, `war_period_started`,
+`war_period_completed`, `war_rank_changed`, `war_fame_changed`,
+`war_member_participation_changed`, `war_member_decks_used_changed`,
+`war_rival_activity_changed`.
 
-- https://eventsourcing.readthedocs.io/en/stable/
+### Observed World — LeagueSeason / Tournament / SpecialEvent
 
-Do not start by forcing the whole bot into the library. Elixir already has a
-large SQLite schema and many runtime paths. The better sequence is:
+`league_season_started`, `league_season_completed`, `tournament_observed`,
+`tournament_started`, `tournament_ended`, `special_event_appeared`,
+`special_event_disappeared`.
 
-1. adopt the event-sourcing model and event taxonomy in Elixir-native tables
-2. implement one or two consumers with explicit tracking
-3. evaluate whether the library should own the event store / notification log /
-   process-application mechanics
+### Elixir's Mind — Detection aggregate
 
-If adopted, the likely fit is a bounded Event Core package rather than a full
-rewrite of bot runtime modules.
+`battle_hot_streak_detected`, `battle_slump_detected`,
+`battle_trophy_push_detected`, `ranked_activity_surge_detected`,
+`ranked_climb_detected`, `cohort_badge_wave_detected`,
+`cohort_achievement_wave_detected`, `card_upgrade_wave_detected`,
+`new_card_unlock_wave_detected`, `inactive_member_risk_detected`,
+`war_momentum_shift_detected`, `war_recovery_needed_detected`,
+`clan_record_detected`, `season_award_granted`.
 
-## Migration Plan
+### Elixir's Mind — Recommendation aggregate
 
-### Phase 0: Inventory and Invariants
+`promotion_candidate_detected`, `demotion_candidate_detected`,
+`kick_candidate_detected`, `leadership_recommendation_refreshed`,
+`leadership_recommendation_suppressed`, `leadership_recommendation_expired`,
+`recommendation_outcome_observed`.
 
-Goal: freeze the conceptual model before schema changes.
+### Elixir's Mind — DecisionCase aggregate
 
-Tasks:
+`decision_case_opened`, `decision_case_refreshed`, `decision_case_deferred`,
+`decision_case_accepted`, `decision_case_rejected`, `decision_case_resolved`.
 
-- Inventory current fact tables, signal types, recommendation/case tables,
-  side-effect ledgers, and runtime jobs.
-- Mark every table as one of:
-  - upstream sample archive
-  - event store
-  - projection
-  - derived state
-  - external side-effect outside the Event Core
-  - compatibility table
-- Define event naming rules.
-- Define dimension keys and canonical IDs for players, cards, badges,
-  achievements, battle modes, war seasons, recommendations, and cases.
-- Define scope rules for public/leadership/system events.
-- Define retention policy for base events and rollups.
-
-Exit criteria:
+### Mind→surface boundary — communication intent
 
-- event taxonomy reviewed
-- table ownership matrix written
-- no schema/code migration started without ownership labels
+`communication_intent_raised`, `communication_intent_fulfilled`,
+`communication_intent_dropped`. (Decision only; no copy/formatting/receipt.)
 
-### Phase 1: Event Store Schema V2
+### System observation
 
-Goal: make the event log capable of being the durable backbone.
+`runtime_job_started`, `runtime_job_succeeded`, `runtime_job_failed`,
+`api_schema_shape_observed`, `api_schema_sentinel_emitted`.
 
-Tasks:
+---
 
-- Add missing columns or create `domain_events`.
-- Add global sequence/position.
-- Add schema version.
-- Add denormalized dimension columns.
-- Add causation/correlation fields.
-- Add consumer tracking table.
-- Add event schema registry in code.
-- Add append helper that enforces:
-  - deterministic `event_key`
-  - append-only writes
-  - scope validation
-  - schema version validation
-  - compact payload size limits
-
-Exit criteria:
-
-- can append base, derived, recommendation, case, and system events
-- can scan by global position
-- can query by player/card/badge/achievement/game mode
-- existing `game_event_stream` readers still work or have a compatibility view
-
-### Phase 2: Base Events From Player Profile Diffs
-
-Goal: ordinary player state changes become events.
-
-Tasks:
-
-- Refactor `snapshot_player_profile()` so its diff engine emits base events.
-- Emit every meaningful profile/card/badge/achievement/ranked delta, not only
-  post-worthy milestones.
-- Keep current signal outputs as compatibility derived events during the phase.
-- Update projections from emitted events.
-- Record source snapshot hash and correlation ID per ingest run.
+## 10. Backfill as fixture (the big payoff)
 
-Important rule:
-
-Do not trigger side effects from base events directly. Existing awareness paths
-remain compatibility consumers until derived-event and recommendation phases are
-ready.
-
-Exit criteria:
+Backfill is not a late nicety. It is the **test fixture and validation oracle**
+for the entire rewrite, because Elixir has been **archiving raw API responses**.
 
-- card level 12 -> 13 is queryable as `card_level_changed`
-- card level 15 -> 16 is queryable as `card_level_changed` and can derive
-  `card_level_milestone_crossed`
-- badge and achievement changes are queryable even when not posted
-- Path of Legends league changes are first-class base events
-
-### Phase 3: Base Events From Roster, War, Awards, Manual Observations
-
-Goal: all primary non-battle observations enter the event store.
-
-Tasks:
-
-- Emit roster membership and role events.
-- Emit donation and activity deltas where useful.
-- Emit war season/week/period/rank/participation events.
-- Emit award-granted events.
-- Emit manual screenshot/clan-voyage observations as events.
-- Emit API sentinel findings as events before notification.
-
-Exit criteria:
-
-- leadership recommendation generators can point to event evidence
-- war Situation can be rebuilt from war projections derived from events
-- API schema sentinel is an event before any external consumer decides how to
-  handle it
-
-### Phase 4: Projection Writers
-
-Goal: make current tables deterministic projections of events.
-
-Tasks:
-
-- Build consumer tracking table:
-  - `consumer_name`
-  - `last_global_position`
-  - `updated_at`
-  - status/error fields
-- Move projection updates behind replayable handlers.
-- Start with low-risk projections:
-  - per-player current state
-  - per-card current state
-  - per-badge current state
-  - per-mode battle summary
-- Add replay tooling against a DB copy.
-- Keep current write paths in shadow until replayed projections match existing
-  tables within defined tolerances.
-
-Exit criteria:
-
-- projections can be rebuilt from event log on a copy
-- projection consumers are idempotent
-- projection lag is visible in admin/status output
-
-### Phase 5: Derived Event Aggregators
-
-Goal: replace signal-first detection with stream aggregators.
-
-Tasks:
-
-- Implement aggregators as consumers with tracking.
-- Port current signal detectors into derived-event emitters:
-  - battle hot streak
-  - battle trophy push
-  - Path of Legends promotion/demotion/global rank
-  - card milestones
-  - badge milestones
-  - achievement milestones
-  - promotion/demotion/kick candidates
-  - war momentum and war recovery signals
-- Add new aggregators:
-  - ranked activity surge
-  - cohort badge wave
-  - cohort achievement wave
-  - card upgrade wave
-  - event-mode participation surge
-
-Exit criteria:
-
-- current signal outcomes have derived-event equivalents
-- derived events include `caused_by_event_ids_json`
-- aggregators can be replayed without duplicate derived events
-- old signal functions are compatibility wrappers, not the primary model
-
-### Phase 6: Leadership Recommendations and Cases
-
-Goal: promotion, demotion, and kick recommendations become Event Core outputs,
-and decision cases become projections/state machines driven by those events.
-
-Tasks:
-
-- Generate leadership-scoped recommendation events from base and derived events.
-- Open/refresh cases from recommendation events.
-- Emit `decision_case_*` events for lifecycle changes.
-- Emit `leadership_recommendation_suppressed` when evidence does not clear the
-  action threshold.
-- Remove recompute-first leadership recommendation behavior once parity is proven.
-
-Exit criteria:
-
-- a promotion/demotion/kick recommendation can trace to base events and derived
-  events
-- deferred cases resurface because their case state says they are due
-- leader decision history is replayable/auditable
-
-### Phase 7: Recommendation Policy and Suppression
-
-Goal: recommendation policy decisions are evented and auditable without encoding
-side-effect behavior.
-
-Tasks:
-
-- Version leadership recommendation policies.
-- Record recommendation threshold decisions with evidence and reason codes.
-- Emit `leadership_recommendation_suppressed` for no-action decisions worth
-  auditing.
-- Keep external side effects outside the Event Core.
-
-Exit criteria:
-
-- every recommendation has a policy version and evidence events
-- every audited suppression has reason codes
-- no presentation-specific fields are required to explain a recommendation
-
-### Phase 8: Situation V2
-
-Goal: Situation is built from event positions, projections, recommendation
-events, and cases.
-
-Tasks:
-
-- Replace signal-batch-first Situation fields with stream-native fields:
-  - `new_events_since_last_awareness`
-  - `event_clusters`
-  - `derived_events_by_priority`
-  - `recommendation_events`
-  - `due_cases`
-  - `projection_snapshots`
-- Keep payload compaction strict.
-- Keep battle-grain rows out of prompts except as aggregates or drilldowns.
-- Add scope-specific filters before prompt assembly.
-
-Exit criteria:
-
-- Elixir can notice a cohort story without a bespoke signal
-- Elixir can reason about ranked, cards, badges, achievements, and war through
-  the same event model
-- public Situation cannot include leadership-only events by construction
-
-### Phase 9: Backfill and Replay
-
-Goal: make history useful without corrupting operational truth.
+The mechanism: backfill replays archived snapshots through the **same aggregate
+command methods that live ingest uses**. `Player.observe_profile(snapshot)` emits
+the identical events whether the snapshot came from `raw_api_payloads` history or
+a fresh poll. There is **one ingest code path**; backfill is just that path fed
+historical input. This means the rewrite is exercised against years of real data
+before it ever goes live.
 
 Backfill sources:
 
-- `member_battle_facts`
-- player profile snapshots
-- card collection snapshots
-- member daily metrics
-- war tables
-- `signal_log`
-- `signal_outcomes`
-- leader action recommendations
-- decision cases
+- `raw_api_payloads` (the archive — primary, highest fidelity)
+- `member_battle_facts`, player profile snapshots, card collection snapshots
+- war tables, member daily metrics
+- `signal_log` / `signal_outcomes`, `leader_action_recommendations`,
+  `decision_cases` (for Mind-context history where it can be reconstructed)
 
 Rules:
 
-- Backfilled events use `source_system='backfill'`.
-- Backfilled `observed_at` is original observation time when known.
-- Backfilled `recorded_at` is backfill time.
-- Never infer more precision than the source supports.
-- Keep backfill scripts idempotent.
-- Run on a DB copy first.
+- Backfilled events stamp `occurred_at`/`observed_at` from the archived
+  observation time; `recorded_at` is backfill time. Never infer more precision
+  than the source supports.
+- Backfill is idempotent (deterministic event keys / aggregate commands).
+- Backfill runs on the isolated copy first.
 
-Exit criteria:
+Because raw payloads are archived, projections of history are not guesswork — they
+are derived from the same upstream truth live ingest sees.
 
-- at least 90 days of core player/battle/war/card/badge history is available
-  where source tables support it
-- backfilled projections match current tables within documented tolerances
+---
 
-### Phase 10: Decommission Compatibility Layers
+## 11. The migration campaign (one pass, not a phased rollout)
 
-Goal: remove duplicate ledgers only after parity.
+This is a **dependency graph executed as a single campaign on an isolated copy**,
+not a release schedule. The ordering exists because each layer is the substrate
+the next is tested against — a foundation bug is far cheaper to catch with zero
+consumers than with eight. The boundaries are **review checkpoints**, not
+shadow-rollout milestones. Nothing ships half-on; it is whole when it merges.
 
-Candidates:
+Isolation: a git worktree + a **copy of `elixir.db`** and a fresh
+`elixir-events.db`. The running bot is untouched until cutover.
 
-- `signal_log` becomes compatibility-only or is replaced by evented completion
-  markers.
-- `signal_outcomes` stays an external side-effect compatibility ledger outside
-  the Event Core until side-effect handling is redesigned.
-- signal dicts become transient DTOs or disappear.
-- direct side-effect paths consume projections rather than detector signals.
-- old project tables remain dormant or are dropped via dedicated FK-safe
-  migration if no longer referenced.
+```
+[0] Phase 0 — settle the gating decisions (§12). No schema work until done.
+      |
+[1] Event Core on the library — Application + aggregate skeletons
+      (Player, Clan, RiverRace, LeagueSeason, Tournament, SpecialEvent;
+       Detection, Recommendation, DecisionCase). Append helpers enforce
+       deterministic commands, scope, schema version.
+      |
+[2] Ingest path — snapshot diff -> aggregate command methods emitting World events.
+      |
+[3] Backfill -> replay raw_api_payloads through the SAME ingest path.   <-- fixture
+      |
+[4] Projection followers + replay harness. Rebuild read models from the log.
+      |
+[5] Aggregators (all of them) as followers emitting Detection events.
+      |
+[6] Recommendation + DecisionCase followers (the Mind state machines).
+      |
+[7] Reactive trigger — communication-policy follower -> communication intents.
+      Cadence reflections (small) over projections.
+      |
+[8] Cutover — point the live bot at the new core; delete old tables/paths.
+```
 
-Exit criteria:
+No compatibility layer at any step. No old/new dual-run. The CR API is the
+self-healing oracle for current state after cutover; only history depends on
+backfill, which is validated once (§12).
 
-- no production path relies on signal grain as the authoritative observation
-- all leadership recommendations trace to base events, derived events, and case
-  events
-- admin/debug tooling reads event store and projections
+---
 
-## Verification Strategy
+## 12. Verification strategy
 
-Unit tests:
+The old plan's oracle was dual-running ("compare new projections to old tables
+forever"). With no compat and an atomic cutover, the oracle changes:
 
-- event key determinism
-- schema validation
-- scope validation
-- upcasting
-- projection replay
-- aggregator replay
-- consumer tracking
+- **Replay determinism (continuous).** Rebuild any projection from the event log
+  twice → byte-identical. Projections are pure functions of events. This is the
+  primary, permanent correctness guarantee.
+- **One-time parity at cutover (then discard).** Rebuild backfilled projections
+  and compare to the current production tables **once**. Divergence is the bug
+  list. Expect a real share of it to be **old-code bugs**, not replay bugs —
+  telling them apart is the work; budget for it. After cutover the old tables are
+  dropped.
+- **API re-poll self-heal.** Current-state projections re-derive on the next poll,
+  so only *history* is unrecoverable — and history comes from backfill validated
+  above.
 
-Integration tests:
+Unit tests: aggregate command determinism, scope validation, event upcasting,
+projection replay, aggregator replay, follower tracking, Recommendation/Case state
+machine invariants.
 
-- player profile diff emits expected base events
-- card upgrade emits ordinary change plus milestone-derived event
-- badge cohort emits wave event
-- ranked battles emit ranked aggregate event
-- leader-action case traces to base events
-- recommendation suppression is recorded
+Integration tests: profile diff emits expected Player events; card upgrade emits
+ordinary change + milestone-derived event; badge cohort emits wave event; ranked
+battles produce ranked aggregate events; recommendation traces to base + derived
+events; suppression is recorded; deferred case resurfaces when due.
 
-Operational checks:
+Operational checks: notification-log append rate by aggregate/family; projection
+lag by follower; failed-follower count; payload size distribution; scope-leakage
+audit; recommendation coverage audit; DB growth and retention.
 
-- event append rate by family
-- projection lag by consumer
-- failed consumer count
-- event payload size distribution
-- scope leakage audit
-- recommendation coverage audit
-- DB growth and retention behavior
+---
 
-Production rollout:
+## 13. Guardrails
 
-1. shadow write events
-2. compare projections against existing tables
-3. enable derived-event aggregators in shadow
-4. compare derived events against current signals
-5. enable recommendation generators in shadow
-6. switch Situation to stream-native read path
-7. retire old paths only after several clean weekly cycles
-
-## Guardrails
-
-- No raw battle flood in prompts.
-- No leadership data in public Situation.
+- No raw battle flood in prompts (battles are facts behind projections/rollups).
+- No leadership data in public-scoped output, by construction.
 - No presentation-specific fields in the Event Core.
-- No destructive schema migration until projections can replay.
-- No derived event without causal evidence.
+- No timezone in the data layer; `America/Chicago` exists only in the one rollup
+  presentation module.
+- No derived/Mind event without causal evidence (`caused_by_event_ids`).
 - No recommendation event without scope, policy version, and evidence.
-- No backfill event that pretends to have real-time precision it does not have.
-- No dependency adoption that forces a bot-wide rewrite before the model is
-  proven.
+- No backfill event that claims real-time precision it does not have.
+- No World aggregate written by anything but ingest; no Mind aggregate written by
+  anything but its owning follower (single-writer invariant).
+- Leadership-scoped payloads are not protected by the library's default SQLite
+  storage — handle sensitive fields explicitly if needed.
 
-## Open Questions
+---
 
-1. Should the existing `game_event_stream` be evolved, or should a new
-   `domain_events` table become the event store with a compatibility view?
-2. How long should full-fidelity non-battle base events be retained?
-3. Which event families should survive indefinitely via rollups?
-4. Should Elixir store upstream raw snapshot hashes for every profile sample?
-5. Should leadership recommendation generators run synchronously during ingest
-   or by scheduled consumers?
-6. Should the Python `eventsourcing` library own the event store after the first
-   native phase, or remain only an architectural reference?
+## 14. Phase 0 decisions that gate everything
 
-## Definition of Done
+No schema or aggregate code until these are written down:
 
-This migration is complete when:
+1. **Aggregate boundaries** — confirm the §5 set; settle Player-vs-Clan ownership
+   of membership; decide whether RiverRace is keyed at week or season grain
+   (recommended: week).
+2. **Battle model (§5.3 #1)** — `BattlesObserved` summary event + battle-fact
+   projection (recommended) vs. dedicated `BattleLog` aggregate.
+3. **Derived-event home (§5.3 #2)** — confirm Mind aggregates + timeline-by-
+   projection.
+4. **Command idempotency** — deterministic rules for *change* events under the
+   aggregate model, including value oscillation (12→13→12) and missed-poll jumps
+   (12→14 across a gap) — you only see snapshots, so define exactly what each
+   emits.
+5. **Key-format hazards** — RiverRace `seasonId` (sequential int) vs LeagueSeason
+   `YYYY-MM` are different keyspaces; Player `progress` keys are opaque side-mode
+   labels and must **not** key aggregates.
+6. **Retention** — produce an actual events/day and 90-day DB-growth estimate
+   (you emit "every meaningful delta" for ~50 members on top of ~350–450
+   battles/day); let the number drive base-event retention vs rollup survival.
+7. **Scope rules** — public / leadership / system_internal, and how leadership
+   payloads are protected given default SQLite storage.
 
-- every meaningful observed player, Clash Royale card, badge, achievement,
-  roster, battle, ranked, war, leadership recommendation, case, and system
-  change is represented as an event or as a projection from events
-- existing current-state tables are documented as projections or upstream sample
-  archives
-- derived observations such as streaks are event-store consumers, not special
-  signal objects
-- promotion, demotion, and kick recommendations are generated by Event Core
-  consumers, not a side system
-- Situation is assembled from stream positions, event clusters, projections,
-  recommendations, and cases
-- Elixir can filter and aggregate by player, event type, card, achievement,
-  badge, battle mode, war season, scope, recommendation type, and case state
+---
+
+## 15. Open questions
+
+Most prior open questions are now decided (library: yes; new store: yes, separate
+file; sync vs scheduled generation: reactive followers). Remaining:
+
+1. Retention horizon for full-fidelity non-battle base events vs rollup-only
+   history (input to Phase 0 #6).
+2. Whether `GlobalTournament` is worth modeling given it is usually empty in
+   sampling.
+3. Whether the cadence reflection set should shrink further over time as reactive
+   coverage proves out.
+
+---
+
+## 16. Definition of Done
+
+v5 is complete when:
+
+- every meaningful observed player, card, badge, achievement, roster, battle,
+  ranked, war, tournament, and special-event change is an event on a World
+  aggregate (or a battle/snapshot fact) and is queryable via projections;
+- every Detection, Recommendation, and DecisionCase is a Mind aggregate, written
+  only by followers, each event carrying causal evidence back into the World;
+- derived observations (streaks, waves) are stream consumers, not signal objects;
+- promotion/demotion/kick recommendations are generated by followers and trace to
+  base + derived events;
+- **Elixir acts reactively** — a noteworthy event triggers a communication intent
+  without a schedule, with a small cadence set as the only time-driven exception;
+- the data layer is UTC-only, with timezone confined to one rollup presentation
+  module;
+- projections are rebuildable from the event log on a copy and verified by replay
+  determinism;
+- the old `game_event_stream` / signal / side-table system is gone, not wrapped.
+```


### PR DESCRIPTION
Rewrites `docs/tasks/elixir-event-sourcing-migration.md` as the v5 architecture. **Doc-only — no code.** For review of the design before any implementation.

## What changed vs. the prior plan

- **Adopt the `eventsourcing` library (SQLite backend)** — its notification log, follower tracking, and upcasting replace the hand-rolled global_position / consumer-table / versioning machinery.
- **Two bounded contexts:**
  - *Observed World* — game-domain observation aggregates (Player, Clan, RiverRace, LeagueSeason, Tournament, SpecialEvent), written **only by ingest**.
  - *Elixir's Mind* — Detection, Recommendation, DecisionCase, written **only by stream followers**, each event carrying causal evidence back into the World.
- **Reactive v5** — events trigger action via a communication-policy follower. The per-tick "Situation" blob is retired; a small cadence set remains.
- **Game modes are dimensions, not aggregates**; bounded *cycles* (River Race week, league season, tournaments, special events) are period aggregates.
- **UTC-only data layer**; timezone confined to one rollup presentation module.
- **Single-campaign migration on an isolated copy**, atomic cutover, **no backward-compat**. Backfill-as-fixture replays archived `raw_api_payloads` through the live ingest path. Verification shifts from dual-running to replay determinism + a one-time parity check.

## Decisions worth a close look
- River Race keyed at the **week**, not the season (note: its `seasonId` is a sequential int, a different keyspace from league's `YYYY-MM`).
- Battles stay **facts**, not an aggregate (so Player never replays thousands of battle events) — §5.3 holds the recommended approach + alternative.
- §14 lists the seven **Phase 0 gating decisions**; the sharpest is command idempotency under snapshot-only observation (value oscillation, missed-poll jumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)